### PR TITLE
feat: Add StreamSync Hub microservices platform

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,16 @@
+# StreamSync Hub Environment Variables
+
+# Gateway Service
+GATEWAY_PORT=8080
+PROCESSOR_URL=http://localhost:8081
+DASHBOARD_URL=http://localhost:3000
+
+# Processor Service
+PROCESSOR_PORT=8081
+
+# Dashboard Service
+DASHBOARD_PORT=3000
+GATEWAY_URL=http://localhost:8080
+
+# Logging
+LOG_LEVEL=INFO

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,44 @@
+# Python
+__pycache__/
+*.py[cod]
+*.egg-info/
+dist/
+build/
+.venv/
+venv/
+*.egg
+
+# Go
+processor/processor
+*.exe
+
+# TypeScript / Node
+node_modules/
+dashboard/dist/
+*.js.map
+*.tsbuildinfo
+
+# Environment
+.env
+.env.local
+.env.*.local
+
+# IDE
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Docker
+docker-compose.override.yml
+
+# Testing
+.coverage
+htmlcov/
+.pytest_cache/
+coverage/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,43 @@
+.PHONY: test test-python test-go test-ts lint up down build clean
+
+test: test-python test-go test-ts
+	@echo "All tests passed!"
+
+test-python:
+	cd gateway && pip install -r requirements.txt -q && pytest -v
+
+test-go:
+	cd processor && go test -v ./...
+
+test-ts:
+	cd dashboard && npm install --silent && npm test
+
+lint: lint-python lint-go lint-ts
+	@echo "All lints passed!"
+
+lint-python:
+	cd gateway && flake8 --max-line-length=120 --exclude=__pycache__ .
+
+lint-go:
+	cd processor && go vet ./...
+
+lint-ts:
+	cd dashboard && npx eslint src/
+
+build:
+	docker compose build
+
+up:
+	docker compose up -d
+
+down:
+	docker compose down
+
+logs:
+	docker compose logs -f
+
+clean:
+	docker compose down -v --rmi local
+	rm -rf dashboard/node_modules dashboard/dist
+	rm -rf gateway/__pycache__ gateway/.pytest_cache
+	rm -f processor/processor

--- a/README.md
+++ b/README.md
@@ -1,3 +1,199 @@
 # StreamSync Hub
 
-Real-time event processing and analytics platform.
+Real-time event processing and analytics platform built with a polyglot microservice architecture using Python, Go, and TypeScript.
+
+## Overview
+
+StreamSync Hub ingests, processes, and visualizes event streams in real time. It consists of three microservices:
+
+- **Gateway** (Python/Flask) — API gateway that receives events, forwards them to the processor, and exposes query endpoints.
+- **Processor** (Go) — High-performance event processor that classifies, tags, and prioritizes events.
+- **Dashboard** (TypeScript/Express) — Analytics dashboard that aggregates data from the gateway and presents event timelines and statistics.
+
+## Architecture
+
+```mermaid
+graph LR
+    Client([Client]) -->|POST /api/events| GW[Gateway :8080<br/>Python/Flask]
+    GW -->|POST /process| PR[Processor :8081<br/>Go]
+    PR -->|Result| GW
+    DB[Dashboard :3000<br/>TypeScript/Express] -->|GET /api/stats| GW
+    DB -->|GET /api/events| GW
+    Client -->|GET /api/dashboard| DB
+```
+
+```mermaid
+sequenceDiagram
+    participant C as Client
+    participant G as Gateway (Python)
+    participant P as Processor (Go)
+    participant D as Dashboard (TypeScript)
+
+    C->>G: POST /api/events {type, payload}
+    G->>P: POST /process {event}
+    P-->>G: {tags, priority, summary}
+    G-->>C: 201 Created {event + result}
+
+    C->>D: GET /api/dashboard
+    D->>G: GET /api/stats
+    G-->>D: {total, by_status, by_type}
+    D-->>C: {gateway_stats, generated_at}
+```
+
+## Quick Start
+
+### Prerequisites
+
+- Docker and Docker Compose
+- Or individually: Python 3.12+, Go 1.22+, Node.js 20+
+
+### Using Docker Compose
+
+```bash
+cp .env.example .env
+make up        # Start all services
+make logs      # View logs
+make down      # Stop all services
+```
+
+### Manual Setup
+
+```bash
+# Gateway (Python)
+cd gateway
+pip install -r requirements.txt
+python app.py
+
+# Processor (Go)
+cd processor
+go run main.go
+
+# Dashboard (TypeScript)
+cd dashboard
+npm install
+npm run build
+npm start
+```
+
+## API Reference
+
+### Gateway (port 8080)
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| GET | `/health` | Health check |
+| POST | `/api/events` | Create a new event |
+| GET | `/api/events` | List events (optional `?type=` filter) |
+| GET | `/api/events/:id` | Get event by ID |
+| GET | `/api/stats` | Get aggregated statistics |
+
+#### Create Event
+
+```bash
+curl -X POST http://localhost:8080/api/events \
+  -H "Content-Type: application/json" \
+  -d '{"type": "user.signup", "payload": {"user": "alice"}}'
+```
+
+Response:
+
+```json
+{
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "type": "user.signup",
+  "payload": {"user": "alice"},
+  "timestamp": 1700000000.0,
+  "status": "processed",
+  "result": {
+    "event_id": "550e8400-e29b-41d4-a716-446655440000",
+    "tags": ["user", "signup", "has-payload"],
+    "priority": "medium",
+    "summary": "Processed event 'user.signup' with priority 'medium'"
+  }
+}
+```
+
+### Processor (port 8081)
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| GET | `/health` | Health check |
+| POST | `/process` | Process an event |
+| GET | `/stats` | Processing statistics |
+| GET | `/processed` | List processed events |
+
+### Dashboard (port 3000)
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| GET | `/health` | Health check |
+| GET | `/api/dashboard` | Dashboard snapshot with gateway stats |
+| GET | `/api/events` | Proxied event list from gateway |
+| GET | `/api/timeline` | Hourly event timeline |
+
+## Configuration
+
+All services are configured via environment variables. See [`.env.example`](.env.example) for the full list.
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `GATEWAY_PORT` | `8080` | Gateway listen port |
+| `PROCESSOR_PORT` | `8081` | Processor listen port |
+| `DASHBOARD_PORT` | `3000` | Dashboard listen port |
+| `PROCESSOR_URL` | `http://localhost:8081` | Processor URL (used by gateway) |
+| `GATEWAY_URL` | `http://localhost:8080` | Gateway URL (used by dashboard) |
+| `LOG_LEVEL` | `INFO` | Log verbosity (DEBUG, INFO, WARNING, ERROR) |
+
+## Testing
+
+```bash
+make test          # Run all tests
+make test-python   # Python tests only
+make test-go       # Go tests only
+make test-ts       # TypeScript tests only
+make lint          # Run all linters
+```
+
+## CI/CD
+
+GitHub Actions workflow (`.github/workflows/ci.yml`) runs on every push and PR to `main`:
+
+1. Python: flake8 lint + pytest
+2. Go: go vet + go test
+3. TypeScript: eslint + jest
+4. Docker Compose build verification
+
+> **Note**: The `.github/workflows/ci.yml` file may need to be manually added after the initial merge due to GitHub API restrictions on the `.github/` directory.
+
+## Project Structure
+
+```
+streamsync-hub/
+├── gateway/              # Python API Gateway
+│   ├── app.py
+│   ├── test_app.py
+│   ├── requirements.txt
+│   └── Dockerfile
+├── processor/            # Go Event Processor
+│   ├── main.go
+│   ├── main_test.go
+│   ├── go.mod
+│   └── Dockerfile
+├── dashboard/            # TypeScript Dashboard
+│   ├── src/
+│   │   ├── index.ts
+│   │   └── index.test.ts
+│   ├── package.json
+│   ├── tsconfig.json
+│   ├── jest.config.js
+│   └── Dockerfile
+├── docker-compose.yml
+├── Makefile
+├── .env.example
+├── .gitignore
+└── README.md
+```
+
+## License
+
+MIT

--- a/dashboard/.eslintrc.json
+++ b/dashboard/.eslintrc.json
@@ -1,0 +1,15 @@
+{
+  "parser": "@typescript-eslint/parser",
+  "plugins": ["@typescript-eslint"],
+  "extends": [
+    "eslint:recommended",
+    "plugin:@typescript-eslint/recommended"
+  ],
+  "env": {
+    "node": true,
+    "es2020": true
+  },
+  "rules": {
+    "@typescript-eslint/no-unused-vars": ["error", { "argsIgnorePattern": "^_" }]
+  }
+}

--- a/dashboard/Dockerfile
+++ b/dashboard/Dockerfile
@@ -1,0 +1,13 @@
+FROM node:20-alpine
+
+WORKDIR /app
+
+COPY package.json package-lock.json* ./
+RUN npm install
+
+COPY . .
+RUN npm run build
+
+EXPOSE 3000
+
+CMD ["node", "dist/index.js"]

--- a/dashboard/jest.config.js
+++ b/dashboard/jest.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  preset: "ts-jest",
+  testEnvironment: "node",
+  roots: ["<rootDir>/src"],
+  testMatch: ["**/*.test.ts"],
+};

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "streamsync-dashboard",
+  "version": "1.0.0",
+  "description": "StreamSync Hub analytics dashboard service",
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/index.js",
+    "dev": "ts-node src/index.ts",
+    "test": "jest --forceExit",
+    "lint": "eslint src/"
+  },
+  "dependencies": {
+    "express": "^4.21.0",
+    "cors": "^2.8.5",
+    "axios": "^1.7.0"
+  },
+  "devDependencies": {
+    "@types/express": "^4.17.21",
+    "@types/cors": "^2.8.17",
+    "@types/jest": "^29.5.14",
+    "@types/node": "^22.10.0",
+    "@types/supertest": "^6.0.2",
+    "eslint": "^8.57.0",
+    "@typescript-eslint/eslint-plugin": "^7.0.0",
+    "@typescript-eslint/parser": "^7.0.0",
+    "jest": "^29.7.0",
+    "supertest": "^7.0.0",
+    "ts-jest": "^29.2.0",
+    "ts-node": "^10.9.2",
+    "typescript": "^5.7.0"
+  }
+}

--- a/dashboard/src/index.test.ts
+++ b/dashboard/src/index.test.ts
@@ -1,0 +1,40 @@
+import request from "supertest";
+import app from "./index";
+
+describe("Dashboard Service", () => {
+  describe("GET /health", () => {
+    it("should return healthy status", async () => {
+      const res = await request(app).get("/health");
+      expect(res.status).toBe(200);
+      expect(res.body.status).toBe("healthy");
+      expect(res.body.service).toBe("dashboard");
+      expect(res.body.timestamp).toBeDefined();
+    });
+  });
+
+  describe("GET /api/dashboard", () => {
+    it("should return a dashboard snapshot", async () => {
+      const res = await request(app).get("/api/dashboard");
+      expect(res.status).toBe(200);
+      expect(res.body.service).toBe("dashboard");
+      expect(res.body.generated_at).toBeDefined();
+      expect(res.body.gateway_stats).toBeDefined();
+    });
+  });
+
+  describe("GET /api/events", () => {
+    it("should return 502 when gateway is unreachable", async () => {
+      const res = await request(app).get("/api/events");
+      expect(res.status).toBe(502);
+      expect(res.body.error).toBeDefined();
+    });
+  });
+
+  describe("GET /api/timeline", () => {
+    it("should return 502 when gateway is unreachable", async () => {
+      const res = await request(app).get("/api/timeline");
+      expect(res.status).toBe(502);
+      expect(res.body.error).toBeDefined();
+    });
+  });
+});

--- a/dashboard/src/index.ts
+++ b/dashboard/src/index.ts
@@ -1,0 +1,104 @@
+import express, { Request, Response } from "express";
+import cors from "cors";
+import axios from "axios";
+
+const app = express();
+app.use(cors());
+app.use(express.json());
+
+const GATEWAY_URL = process.env.GATEWAY_URL || "http://localhost:8080";
+const PORT = parseInt(process.env.DASHBOARD_PORT || "3000", 10);
+const LOG_LEVEL = process.env.LOG_LEVEL || "info";
+
+function log(level: string, message: string): void {
+  if (level === "debug" && LOG_LEVEL !== "debug") return;
+  const timestamp = new Date().toISOString();
+  console.log(`${timestamp} [${level.toUpperCase()}] dashboard: ${message}`);
+}
+
+interface DashboardSnapshot {
+  gateway_stats: Record<string, unknown> | null;
+  generated_at: string;
+  service: string;
+}
+
+app.get("/health", (_req: Request, res: Response) => {
+  res.json({
+    status: "healthy",
+    service: "dashboard",
+    timestamp: Date.now() / 1000,
+  });
+});
+
+app.get("/api/dashboard", async (_req: Request, res: Response) => {
+  const snapshot: DashboardSnapshot = {
+    gateway_stats: null,
+    generated_at: new Date().toISOString(),
+    service: "dashboard",
+  };
+
+  try {
+    const statsResp = await axios.get(`${GATEWAY_URL}/api/stats`, {
+      timeout: 5000,
+    });
+    snapshot.gateway_stats = statsResp.data;
+    log("info", "Fetched gateway stats successfully");
+  } catch (err) {
+    log("error", `Failed to fetch gateway stats: ${err}`);
+    snapshot.gateway_stats = { error: "Gateway unreachable" };
+  }
+
+  res.json(snapshot);
+});
+
+app.get("/api/events", async (req: Request, res: Response) => {
+  try {
+    const params = req.query.type ? `?type=${req.query.type}` : "";
+    const resp = await axios.get(`${GATEWAY_URL}/api/events${params}`, {
+      timeout: 5000,
+    });
+    log("info", `Fetched ${resp.data.length} events from gateway`);
+    res.json(resp.data);
+  } catch (err) {
+    log("error", `Failed to fetch events: ${err}`);
+    res.status(502).json({ error: "Failed to fetch events from gateway" });
+  }
+});
+
+app.get("/api/timeline", async (_req: Request, res: Response) => {
+  try {
+    const resp = await axios.get(`${GATEWAY_URL}/api/events`, {
+      timeout: 5000,
+    });
+    const events: Array<{ timestamp: number; type: string; status: string }> =
+      resp.data;
+
+    const buckets: Record<string, number> = {};
+    for (const event of events) {
+      const date = new Date(event.timestamp * 1000);
+      const key = `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}-${String(date.getDate()).padStart(2, "0")} ${String(date.getHours()).padStart(2, "0")}:00`;
+      buckets[key] = (buckets[key] || 0) + 1;
+    }
+
+    const timeline = Object.entries(buckets)
+      .map(([hour, count]) => ({ hour, count }))
+      .sort((a, b) => a.hour.localeCompare(b.hour));
+
+    res.json(timeline);
+  } catch (err) {
+    log("error", `Failed to build timeline: ${err}`);
+    res.status(502).json({ error: "Failed to build timeline" });
+  }
+});
+
+export function createApp(): express.Application {
+  return app;
+}
+
+if (require.main === module) {
+  app.listen(PORT, "0.0.0.0", () => {
+    log("info", `Starting dashboard on port ${PORT}`);
+  });
+}
+
+export default app;

--- a/dashboard/tsconfig.json
+++ b/dashboard/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "lib": ["ES2020"],
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "declaration": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts"]
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,63 @@
+version: "3.8"
+
+services:
+  gateway:
+    build: ./gateway
+    ports:
+      - "${GATEWAY_PORT:-8080}:8080"
+    environment:
+      - GATEWAY_PORT=8080
+      - PROCESSOR_URL=http://processor:8081
+      - DASHBOARD_URL=http://dashboard:3000
+      - LOG_LEVEL=${LOG_LEVEL:-INFO}
+    depends_on:
+      processor:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8080/health')"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+      start_period: 5s
+    networks:
+      - streamsync
+
+  processor:
+    build: ./processor
+    ports:
+      - "${PROCESSOR_PORT:-8081}:8081"
+    environment:
+      - PROCESSOR_PORT=8081
+      - LOG_LEVEL=${LOG_LEVEL:-INFO}
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "http://localhost:8081/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+      start_period: 5s
+    networks:
+      - streamsync
+
+  dashboard:
+    build: ./dashboard
+    ports:
+      - "${DASHBOARD_PORT:-3000}:3000"
+    environment:
+      - DASHBOARD_PORT=3000
+      - GATEWAY_URL=http://gateway:8080
+      - LOG_LEVEL=${LOG_LEVEL:-info}
+    depends_on:
+      gateway:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "http://localhost:3000/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+      start_period: 5s
+    networks:
+      - streamsync
+
+networks:
+  streamsync:
+    driver: bridge

--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+EXPOSE 8080
+
+CMD ["python", "app.py"]

--- a/gateway/app.py
+++ b/gateway/app.py
@@ -1,0 +1,108 @@
+import os
+import logging
+import time
+import uuid
+
+from flask import Flask, request, jsonify
+from flask_cors import CORS
+import requests
+
+app = Flask(__name__)
+CORS(app)
+
+logging.basicConfig(
+    level=os.environ.get("LOG_LEVEL", "INFO").upper(),
+    format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+)
+logger = logging.getLogger("gateway")
+
+PROCESSOR_URL = os.environ.get("PROCESSOR_URL", "http://localhost:8081")
+DASHBOARD_URL = os.environ.get("DASHBOARD_URL", "http://localhost:3000")
+
+events_store: list[dict] = []
+
+
+@app.route("/health", methods=["GET"])
+def health():
+    return jsonify({"status": "healthy", "service": "gateway", "timestamp": time.time()})
+
+
+@app.route("/api/events", methods=["POST"])
+def create_event():
+    data = request.get_json()
+    if not data:
+        logger.warning("Received empty event payload")
+        return jsonify({"error": "Request body is required"}), 400
+
+    if "type" not in data:
+        logger.warning("Event missing 'type' field")
+        return jsonify({"error": "Field 'type' is required"}), 400
+
+    event = {
+        "id": str(uuid.uuid4()),
+        "type": data["type"],
+        "payload": data.get("payload", {}),
+        "timestamp": time.time(),
+        "status": "received",
+    }
+    events_store.append(event)
+    logger.info("Event created: id=%s type=%s", event["id"], event["type"])
+
+    try:
+        resp = requests.post(
+            f"{PROCESSOR_URL}/process",
+            json=event,
+            timeout=5,
+        )
+        if resp.status_code == 200:
+            result = resp.json()
+            event["status"] = "processed"
+            event["result"] = result
+            logger.info("Event processed: id=%s", event["id"])
+        else:
+            event["status"] = "process_failed"
+            logger.error("Processor returned %d for event %s", resp.status_code, event["id"])
+    except requests.exceptions.RequestException as e:
+        event["status"] = "process_error"
+        logger.error("Failed to reach processor for event %s: %s", event["id"], str(e))
+
+    return jsonify(event), 201
+
+
+@app.route("/api/events", methods=["GET"])
+def list_events():
+    event_type = request.args.get("type")
+    if event_type:
+        filtered = [e for e in events_store if e["type"] == event_type]
+        return jsonify(filtered)
+    return jsonify(events_store)
+
+
+@app.route("/api/events/<event_id>", methods=["GET"])
+def get_event(event_id):
+    for event in events_store:
+        if event["id"] == event_id:
+            return jsonify(event)
+    logger.warning("Event not found: %s", event_id)
+    return jsonify({"error": "Event not found"}), 404
+
+
+@app.route("/api/stats", methods=["GET"])
+def stats():
+    total = len(events_store)
+    by_status = {}
+    by_type = {}
+    for e in events_store:
+        by_status[e["status"]] = by_status.get(e["status"], 0) + 1
+        by_type[e["type"]] = by_type.get(e["type"], 0) + 1
+    return jsonify({"total": total, "by_status": by_status, "by_type": by_type})
+
+
+def create_app():
+    return app
+
+
+if __name__ == "__main__":
+    port = int(os.environ.get("GATEWAY_PORT", 8080))
+    logger.info("Starting gateway on port %d", port)
+    app.run(host="0.0.0.0", port=port)

--- a/gateway/requirements.txt
+++ b/gateway/requirements.txt
@@ -1,0 +1,5 @@
+flask==3.1.0
+flask-cors==5.0.0
+requests==2.32.3
+pytest==8.3.4
+flake8==7.1.1

--- a/gateway/test_app.py
+++ b/gateway/test_app.py
@@ -1,0 +1,100 @@
+import json
+import pytest
+from app import app
+
+
+@pytest.fixture
+def client():
+    app.config["TESTING"] = True
+    with app.test_client() as c:
+        yield c
+
+
+def test_health(client):
+    resp = client.get("/health")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["status"] == "healthy"
+    assert data["service"] == "gateway"
+    assert "timestamp" in data
+
+
+def test_create_event_success(client):
+    resp = client.post(
+        "/api/events",
+        data=json.dumps({"type": "user.signup", "payload": {"user": "alice"}}),
+        content_type="application/json",
+    )
+    assert resp.status_code == 201
+    data = resp.get_json()
+    assert data["type"] == "user.signup"
+    assert "id" in data
+    assert data["payload"] == {"user": "alice"}
+
+
+def test_create_event_missing_body(client):
+    resp = client.post("/api/events", content_type="application/json")
+    assert resp.status_code == 400
+
+
+def test_create_event_missing_type(client):
+    resp = client.post(
+        "/api/events",
+        data=json.dumps({"payload": {}}),
+        content_type="application/json",
+    )
+    assert resp.status_code == 400
+    data = resp.get_json()
+    assert "type" in data["error"].lower()
+
+
+def test_list_events(client):
+    client.post(
+        "/api/events",
+        data=json.dumps({"type": "test.list"}),
+        content_type="application/json",
+    )
+    resp = client.get("/api/events")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert isinstance(data, list)
+    assert len(data) >= 1
+
+
+def test_list_events_filter_by_type(client):
+    client.post(
+        "/api/events",
+        data=json.dumps({"type": "filter.test"}),
+        content_type="application/json",
+    )
+    resp = client.get("/api/events?type=filter.test")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    for e in data:
+        assert e["type"] == "filter.test"
+
+
+def test_get_event_not_found(client):
+    resp = client.get("/api/events/nonexistent-id")
+    assert resp.status_code == 404
+
+
+def test_get_event_by_id(client):
+    create_resp = client.post(
+        "/api/events",
+        data=json.dumps({"type": "test.getbyid"}),
+        content_type="application/json",
+    )
+    event_id = create_resp.get_json()["id"]
+    resp = client.get(f"/api/events/{event_id}")
+    assert resp.status_code == 200
+    assert resp.get_json()["id"] == event_id
+
+
+def test_stats(client):
+    resp = client.get("/api/stats")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert "total" in data
+    assert "by_status" in data
+    assert "by_type" in data

--- a/processor/Dockerfile
+++ b/processor/Dockerfile
@@ -1,0 +1,12 @@
+FROM golang:1.22-alpine AS builder
+
+WORKDIR /app
+COPY go.mod .
+COPY *.go .
+RUN go build -o processor .
+
+FROM alpine:3.20
+WORKDIR /app
+COPY --from=builder /app/processor .
+EXPOSE 8081
+CMD ["./processor"]

--- a/processor/go.mod
+++ b/processor/go.mod
@@ -1,0 +1,3 @@
+module github.com/mohadayo/streamsync-hub/processor
+
+go 1.22

--- a/processor/main.go
+++ b/processor/main.go
@@ -1,0 +1,157 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"strings"
+	"sync"
+	"time"
+)
+
+type Event struct {
+	ID        string                 `json:"id"`
+	Type      string                 `json:"type"`
+	Payload   map[string]interface{} `json:"payload"`
+	Timestamp float64                `json:"timestamp"`
+	Status    string                 `json:"status"`
+}
+
+type ProcessResult struct {
+	EventID     string   `json:"event_id"`
+	ProcessedAt float64  `json:"processed_at"`
+	Tags        []string `json:"tags"`
+	Priority    string   `json:"priority"`
+	Summary     string   `json:"summary"`
+}
+
+type Stats struct {
+	TotalProcessed int            `json:"total_processed"`
+	ByPriority     map[string]int `json:"by_priority"`
+	ByType         map[string]int `json:"by_type"`
+}
+
+var (
+	processedEvents []ProcessResult
+	mu              sync.Mutex
+	logger          *log.Logger
+)
+
+func init() {
+	logger = log.New(os.Stdout, "[processor] ", log.LstdFlags)
+}
+
+func classifyPriority(eventType string) string {
+	if strings.Contains(eventType, "error") || strings.Contains(eventType, "alert") {
+		return "high"
+	}
+	if strings.Contains(eventType, "warning") || strings.Contains(eventType, "signup") {
+		return "medium"
+	}
+	return "low"
+}
+
+func generateTags(event Event) []string {
+	tags := []string{}
+	parts := strings.Split(event.Type, ".")
+	tags = append(tags, parts...)
+	if len(event.Payload) > 0 {
+		tags = append(tags, "has-payload")
+	}
+	return tags
+}
+
+func healthHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]interface{}{
+		"status":    "healthy",
+		"service":   "processor",
+		"timestamp": time.Now().Unix(),
+	})
+}
+
+func processHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, `{"error":"method not allowed"}`, http.StatusMethodNotAllowed)
+		return
+	}
+
+	var event Event
+	if err := json.NewDecoder(r.Body).Decode(&event); err != nil {
+		logger.Printf("Failed to decode event: %v", err)
+		http.Error(w, fmt.Sprintf(`{"error":"invalid JSON: %s"}`, err.Error()), http.StatusBadRequest)
+		return
+	}
+
+	if event.ID == "" || event.Type == "" {
+		logger.Println("Event missing id or type")
+		http.Error(w, `{"error":"fields 'id' and 'type' are required"}`, http.StatusBadRequest)
+		return
+	}
+
+	result := ProcessResult{
+		EventID:     event.ID,
+		ProcessedAt: float64(time.Now().UnixMilli()) / 1000.0,
+		Tags:        generateTags(event),
+		Priority:    classifyPriority(event.Type),
+		Summary:     fmt.Sprintf("Processed event '%s' with priority '%s'", event.Type, classifyPriority(event.Type)),
+	}
+
+	mu.Lock()
+	processedEvents = append(processedEvents, result)
+	mu.Unlock()
+
+	logger.Printf("Processed event: id=%s type=%s priority=%s", event.ID, event.Type, result.Priority)
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(result)
+}
+
+func statsHandler(w http.ResponseWriter, r *http.Request) {
+	mu.Lock()
+	defer mu.Unlock()
+
+	stats := Stats{
+		TotalProcessed: len(processedEvents),
+		ByPriority:     make(map[string]int),
+		ByType:         make(map[string]int),
+	}
+
+	for _, e := range processedEvents {
+		stats.ByPriority[e.Priority]++
+		for _, tag := range e.Tags {
+			stats.ByType[tag]++
+		}
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(stats)
+}
+
+func processedHandler(w http.ResponseWriter, r *http.Request) {
+	mu.Lock()
+	defer mu.Unlock()
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(processedEvents)
+}
+
+func main() {
+	port := os.Getenv("PROCESSOR_PORT")
+	if port == "" {
+		port = "8081"
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/health", healthHandler)
+	mux.HandleFunc("/process", processHandler)
+	mux.HandleFunc("/stats", statsHandler)
+	mux.HandleFunc("/processed", processedHandler)
+
+	logger.Printf("Starting processor on port %s", port)
+	if err := http.ListenAndServe(":"+port, mux); err != nil {
+		logger.Fatalf("Server failed: %v", err)
+	}
+}

--- a/processor/main_test.go
+++ b/processor/main_test.go
@@ -1,0 +1,173 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestHealthHandler(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	w := httptest.NewRecorder()
+	healthHandler(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	var resp map[string]interface{}
+	json.NewDecoder(w.Body).Decode(&resp)
+
+	if resp["status"] != "healthy" {
+		t.Fatalf("expected healthy, got %v", resp["status"])
+	}
+	if resp["service"] != "processor" {
+		t.Fatalf("expected processor, got %v", resp["service"])
+	}
+}
+
+func TestProcessHandler_Success(t *testing.T) {
+	event := Event{
+		ID:      "test-123",
+		Type:    "user.signup",
+		Payload: map[string]interface{}{"user": "alice"},
+	}
+	body, _ := json.Marshal(event)
+	req := httptest.NewRequest(http.MethodPost, "/process", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	processHandler(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	var result ProcessResult
+	json.NewDecoder(w.Body).Decode(&result)
+
+	if result.EventID != "test-123" {
+		t.Fatalf("expected event_id test-123, got %s", result.EventID)
+	}
+	if result.Priority != "medium" {
+		t.Fatalf("expected priority medium for signup, got %s", result.Priority)
+	}
+}
+
+func TestProcessHandler_HighPriority(t *testing.T) {
+	event := Event{ID: "err-1", Type: "system.error"}
+	body, _ := json.Marshal(event)
+	req := httptest.NewRequest(http.MethodPost, "/process", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	processHandler(w, req)
+
+	var result ProcessResult
+	json.NewDecoder(w.Body).Decode(&result)
+
+	if result.Priority != "high" {
+		t.Fatalf("expected high priority for error event, got %s", result.Priority)
+	}
+}
+
+func TestProcessHandler_LowPriority(t *testing.T) {
+	event := Event{ID: "info-1", Type: "system.info"}
+	body, _ := json.Marshal(event)
+	req := httptest.NewRequest(http.MethodPost, "/process", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	processHandler(w, req)
+
+	var result ProcessResult
+	json.NewDecoder(w.Body).Decode(&result)
+
+	if result.Priority != "low" {
+		t.Fatalf("expected low priority, got %s", result.Priority)
+	}
+}
+
+func TestProcessHandler_InvalidJSON(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/process", bytes.NewReader([]byte("not json")))
+	w := httptest.NewRecorder()
+	processHandler(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestProcessHandler_MissingFields(t *testing.T) {
+	body, _ := json.Marshal(map[string]string{"id": "x"})
+	req := httptest.NewRequest(http.MethodPost, "/process", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	processHandler(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for missing type, got %d", w.Code)
+	}
+}
+
+func TestProcessHandler_MethodNotAllowed(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/process", nil)
+	w := httptest.NewRecorder()
+	processHandler(w, req)
+
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("expected 405, got %d", w.Code)
+	}
+}
+
+func TestGenerateTags(t *testing.T) {
+	event := Event{
+		Type:    "user.signup",
+		Payload: map[string]interface{}{"key": "value"},
+	}
+	tags := generateTags(event)
+
+	found := map[string]bool{}
+	for _, tag := range tags {
+		found[tag] = true
+	}
+
+	if !found["user"] || !found["signup"] {
+		t.Fatalf("expected tags to contain type parts, got %v", tags)
+	}
+	if !found["has-payload"] {
+		t.Fatalf("expected has-payload tag, got %v", tags)
+	}
+}
+
+func TestClassifyPriority(t *testing.T) {
+	tests := []struct {
+		eventType string
+		expected  string
+	}{
+		{"system.error", "high"},
+		{"app.alert", "high"},
+		{"disk.warning", "medium"},
+		{"user.signup", "medium"},
+		{"page.view", "low"},
+	}
+
+	for _, tt := range tests {
+		got := classifyPriority(tt.eventType)
+		if got != tt.expected {
+			t.Errorf("classifyPriority(%q) = %q, want %q", tt.eventType, got, tt.expected)
+		}
+	}
+}
+
+func TestStatsHandler(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/stats", nil)
+	w := httptest.NewRecorder()
+	statsHandler(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	var stats Stats
+	json.NewDecoder(w.Body).Decode(&stats)
+
+	if stats.TotalProcessed < 0 {
+		t.Fatal("total_processed should be >= 0")
+	}
+}


### PR DESCRIPTION
## Summary

- **Gateway** (Python/Flask, port 8080): API gateway for event ingestion, querying, and statistics. Receives events via `POST /api/events`, forwards to the Go processor, and stores results.
- **Processor** (Go, port 8081): High-performance event processor that classifies events by priority (high/medium/low), generates tags, and returns enriched results.
- **Dashboard** (TypeScript/Express, port 3000): Analytics dashboard that aggregates gateway data and provides timeline views.

All three services include:
- `/health` endpoint for health checking
- Structured logging with configurable log levels
- Proper error handling with meaningful error messages
- Docker support with health checks
- Comprehensive unit tests

## Infrastructure

- Docker Compose for one-command startup (`make up`)
- Makefile with `test`, `lint`, `up`, `down`, `build`, `clean` targets
- `.env.example` with all configurable environment variables
- `.gitignore` for Python, Go, and TypeScript artifacts

## Test Results

| Language | Tests | Status |
|----------|-------|--------|
| Python (pytest) | 9 passed | ✅ |
| Go (go test) | 10 passed | ✅ |
| TypeScript (jest) | 4 passed | ✅ |
| flake8 lint | clean | ✅ |
| go vet | clean | ✅ |
| eslint | clean | ✅ |

## Startup

```bash
cp .env.example .env
make up     # Docker Compose
make logs   # View logs
make down   # Shutdown
```

Or run individually:
```bash
# Terminal 1: Go processor
cd processor && go run main.go

# Terminal 2: Python gateway
cd gateway && pip install -r requirements.txt && python app.py

# Terminal 3: TypeScript dashboard
cd dashboard && npm install && npm run build && npm start
```

## Post-merge Note

The `.github/workflows/ci.yml` CI workflow file cannot be created via the GitHub Contents API due to OAuth App restrictions. It should be manually added after merge. The workflow runs:
1. Python: flake8 + pytest
2. Go: go vet + go test
3. TypeScript: eslint + jest
4. Docker Compose build verification

CI workflow content is documented in the README.