### PR TITLE
Gateway テストの分離改善

### DIFF
--- a/gateway/test_app.py
+++ b/gateway/test_app.py
@@ -1,6 +1,13 @@
 import json
 import pytest
-from app import app
+from app import app, events_store
+
+
+@pytest.fixture(autouse=True)
+def clear_events():
+    events_store.clear()
+    yield
+    events_store.clear()
 
 
 @pytest.fixture
@@ -58,7 +65,7 @@ def test_list_events(client):
     assert resp.status_code == 200
     data = resp.get_json()
     assert isinstance(data, list)
-    assert len(data) >= 1
+    assert len(data) == 1
 
 
 def test_list_events_filter_by_type(client):
@@ -67,9 +74,15 @@ def test_list_events_filter_by_type(client):
         data=json.dumps({"type": "filter.test"}),
         content_type="application/json",
     )
+    client.post(
+        "/api/events",
+        data=json.dumps({"type": "other.type"}),
+        content_type="application/json",
+    )
     resp = client.get("/api/events?type=filter.test")
     assert resp.status_code == 200
     data = resp.get_json()
+    assert len(data) == 1
     for e in data:
         assert e["type"] == "filter.test"
 
@@ -95,6 +108,24 @@ def test_stats(client):
     resp = client.get("/api/stats")
     assert resp.status_code == 200
     data = resp.get_json()
-    assert "total" in data
+    assert data["total"] == 0
     assert "by_status" in data
     assert "by_type" in data
+
+
+def test_stats_with_events(client):
+    client.post(
+        "/api/events",
+        data=json.dumps({"type": "stat.test"}),
+        content_type="application/json",
+    )
+    client.post(
+        "/api/events",
+        data=json.dumps({"type": "stat.test"}),
+        content_type="application/json",
+    )
+    resp = client.get("/api/stats")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["total"] == 2
+    assert data["by_type"]["stat.test"] == 2


### PR DESCRIPTION
## 変更概要

- `gateway/test_app.py` に `autouse=True` のフィクスチャを追加し、テスト間で `events_store` をクリアするように変更
- テストのアサーションを正確な件数チェックに改善（`>= 1` → `== 1` 等）
- `test_stats_with_events` テストを追加し、統計エンドポイントのカウントを検証
- `test_list_events_filter_by_type` に複数タイプのイベント作成を追加し、フィルタリングの正確性を検証

Closes #2

## 動作確認手順

```bash
cd gateway && pip install -r requirements.txt && pytest -v
```