### PR TITLE
feat: Gateway にイベント削除エンドポイントを追加

### DIFF
--- a/gateway/app.py
+++ b/gateway/app.py
@@ -87,6 +87,17 @@ def get_event(event_id):
     return jsonify({"error": "Event not found"}), 404
 
 
+@app.route("/api/events/<event_id>", methods=["DELETE"])
+def delete_event(event_id):
+    for i, event in enumerate(events_store):
+        if event["id"] == event_id:
+            deleted = events_store.pop(i)
+            logger.info("Event deleted: id=%s type=%s", deleted["id"], deleted["type"])
+            return jsonify({"message": "Event deleted", "event": deleted})
+    logger.warning("Event not found for deletion: %s", event_id)
+    return jsonify({"error": "Event not found"}), 404
+
+
 @app.route("/api/stats", methods=["GET"])
 def stats():
     total = len(events_store)

--- a/gateway/test_app.py
+++ b/gateway/test_app.py
@@ -104,6 +104,53 @@ def test_get_event_by_id(client):
     assert resp.get_json()["id"] == event_id
 
 
+def test_delete_event_success(client):
+    create_resp = client.post(
+        "/api/events",
+        data=json.dumps({"type": "test.delete"}),
+        content_type="application/json",
+    )
+    event_id = create_resp.get_json()["id"]
+
+    resp = client.delete(f"/api/events/{event_id}")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["message"] == "Event deleted"
+    assert data["event"]["id"] == event_id
+
+    get_resp = client.get(f"/api/events/{event_id}")
+    assert get_resp.status_code == 404
+
+
+def test_delete_event_not_found(client):
+    resp = client.delete("/api/events/nonexistent-id")
+    assert resp.status_code == 404
+    data = resp.get_json()
+    assert "not found" in data["error"].lower()
+
+
+def test_delete_event_updates_stats(client):
+    client.post(
+        "/api/events",
+        data=json.dumps({"type": "stat.del"}),
+        content_type="application/json",
+    )
+    create_resp = client.post(
+        "/api/events",
+        data=json.dumps({"type": "stat.del"}),
+        content_type="application/json",
+    )
+    event_id = create_resp.get_json()["id"]
+
+    stats_before = client.get("/api/stats").get_json()
+    assert stats_before["total"] == 2
+
+    client.delete(f"/api/events/{event_id}")
+
+    stats_after = client.get("/api/stats").get_json()
+    assert stats_after["total"] == 1
+
+
 def test_stats(client):
     resp = client.get("/api/stats")
     assert resp.status_code == 200


### PR DESCRIPTION
## 変更概要
- `DELETE /api/events/<event_id>` エンドポイントを追加
- 削除成功時は 200 + 削除されたイベント情報を返却
- 存在しないIDの場合は 404 を返却
- ログ出力を追加

## テスト
- `test_delete_event_success`: 作成→削除→取得で404確認
- `test_delete_event_not_found`: 存在しないID削除で404
- `test_delete_event_updates_stats`: 削除後のstats反映確認

## 動作確認手順
```bash
cd gateway && pip install -r requirements.txt && pytest -v
```

Closes #4