### PR TITLE
feat: Gateway にイベントストア上限とペイロードサイズ制限を追加

### DIFF
--- a/gateway/app.py
+++ b/gateway/app.py
@@ -18,6 +18,8 @@ logger = logging.getLogger("gateway")
 
 PROCESSOR_URL = os.environ.get("PROCESSOR_URL", "http://localhost:8081")
 DASHBOARD_URL = os.environ.get("DASHBOARD_URL", "http://localhost:3000")
+MAX_EVENTS = int(os.environ.get("MAX_EVENTS", "10000"))
+MAX_PAYLOAD_SIZE = int(os.environ.get("MAX_PAYLOAD_SIZE", str(1024 * 1024)))
 
 events_store: list[dict] = []
 
@@ -29,6 +31,11 @@ def health():
 
 @app.route("/api/events", methods=["POST"])
 def create_event():
+    content_length = request.content_length or 0
+    if content_length > MAX_PAYLOAD_SIZE:
+        logger.warning("Payload too large: %d bytes (max %d)", content_length, MAX_PAYLOAD_SIZE)
+        return jsonify({"error": "Payload too large", "max_bytes": MAX_PAYLOAD_SIZE}), 413
+
     data = request.get_json()
     if not data:
         logger.warning("Received empty event payload")
@@ -46,6 +53,12 @@ def create_event():
         "status": "received",
     }
     events_store.append(event)
+
+    if len(events_store) > MAX_EVENTS:
+        removed = len(events_store) - MAX_EVENTS
+        del events_store[:removed]
+        logger.info("Evicted %d old events (store capped at %d)", removed, MAX_EVENTS)
+
     logger.info("Event created: id=%s type=%s", event["id"], event["type"])
 
     try:

--- a/gateway/test_app.py
+++ b/gateway/test_app.py
@@ -176,3 +176,43 @@ def test_stats_with_events(client):
     data = resp.get_json()
     assert data["total"] == 2
     assert data["by_type"]["stat.test"] == 2
+
+
+def test_events_store_max_capacity(client, monkeypatch):
+    monkeypatch.setattr("app.MAX_EVENTS", 3)
+    for i in range(5):
+        client.post(
+            "/api/events",
+            data=json.dumps({"type": f"cap.test.{i}"}),
+            content_type="application/json",
+        )
+    resp = client.get("/api/events")
+    data = resp.get_json()
+    assert len(data) == 3
+    types = [e["type"] for e in data]
+    assert "cap.test.0" not in types
+    assert "cap.test.1" not in types
+    assert "cap.test.4" in types
+
+
+def test_payload_too_large(client, monkeypatch):
+    monkeypatch.setattr("app.MAX_PAYLOAD_SIZE", 50)
+    large_payload = json.dumps({"type": "test", "payload": {"data": "x" * 100}})
+    resp = client.post(
+        "/api/events",
+        data=large_payload,
+        content_type="application/json",
+    )
+    assert resp.status_code == 413
+    data = resp.get_json()
+    assert "too large" in data["error"].lower()
+
+
+def test_payload_within_limit(client, monkeypatch):
+    monkeypatch.setattr("app.MAX_PAYLOAD_SIZE", 10000)
+    resp = client.post(
+        "/api/events",
+        data=json.dumps({"type": "small.event"}),
+        content_type="application/json",
+    )
+    assert resp.status_code == 201


### PR DESCRIPTION
## 変更概要

- `MAX_EVENTS` 環境変数（デフォルト 10000）でイベントストアの上限を追加。超過時は古いイベントから自動削除（FIFO）
- `MAX_PAYLOAD_SIZE` 環境変数（デフォルト 1MB）でリクエストペイロードサイズを制限。超過時は 413 Payload Too Large を返却
- 新機能に対するユニットテスト3件を追加（合計16テスト全パス）

Closes #6

## 動作確認
- `flake8` lint: パス
- `pytest -v`: 16テスト全パス