### PR TITLE
feat: GET /api/events にページネーション対応を追加

### DIFF
--- a/gateway/app.py
+++ b/gateway/app.py
@@ -20,6 +20,7 @@ PROCESSOR_URL = os.environ.get("PROCESSOR_URL", "http://localhost:8081")
 DASHBOARD_URL = os.environ.get("DASHBOARD_URL", "http://localhost:3000")
 MAX_EVENTS = int(os.environ.get("MAX_EVENTS", "10000"))
 MAX_PAYLOAD_SIZE = int(os.environ.get("MAX_PAYLOAD_SIZE", str(1024 * 1024)))
+DEFAULT_PAGE_LIMIT = int(os.environ.get("DEFAULT_PAGE_LIMIT", "50"))
 
 events_store: list[dict] = []
 
@@ -85,10 +86,27 @@ def create_event():
 @app.route("/api/events", methods=["GET"])
 def list_events():
     event_type = request.args.get("type")
+    limit = request.args.get("limit", DEFAULT_PAGE_LIMIT, type=int)
+    offset = request.args.get("offset", 0, type=int)
+
+    if limit < 0:
+        limit = DEFAULT_PAGE_LIMIT
+    if offset < 0:
+        offset = 0
+
+    filtered = events_store
     if event_type:
         filtered = [e for e in events_store if e["type"] == event_type]
-        return jsonify(filtered)
-    return jsonify(events_store)
+
+    total = len(filtered)
+    paginated = filtered[offset:offset + limit]
+
+    return jsonify({
+        "events": paginated,
+        "total": total,
+        "limit": limit,
+        "offset": offset,
+    })
 
 
 @app.route("/api/events/<event_id>", methods=["GET"])

--- a/gateway/test_app.py
+++ b/gateway/test_app.py
@@ -64,8 +64,10 @@ def test_list_events(client):
     resp = client.get("/api/events")
     assert resp.status_code == 200
     data = resp.get_json()
-    assert isinstance(data, list)
-    assert len(data) == 1
+    assert "events" in data
+    assert "total" in data
+    assert data["total"] == 1
+    assert len(data["events"]) == 1
 
 
 def test_list_events_filter_by_type(client):
@@ -82,9 +84,101 @@ def test_list_events_filter_by_type(client):
     resp = client.get("/api/events?type=filter.test")
     assert resp.status_code == 200
     data = resp.get_json()
-    assert len(data) == 1
-    for e in data:
+    assert data["total"] == 1
+    assert len(data["events"]) == 1
+    for e in data["events"]:
         assert e["type"] == "filter.test"
+
+
+def test_list_events_pagination_limit(client):
+    for i in range(5):
+        client.post(
+            "/api/events",
+            data=json.dumps({"type": f"page.test.{i}"}),
+            content_type="application/json",
+        )
+    resp = client.get("/api/events?limit=2")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["total"] == 5
+    assert len(data["events"]) == 2
+    assert data["limit"] == 2
+    assert data["offset"] == 0
+
+
+def test_list_events_pagination_offset(client):
+    for i in range(5):
+        client.post(
+            "/api/events",
+            data=json.dumps({"type": f"page.test.{i}"}),
+            content_type="application/json",
+        )
+    resp = client.get("/api/events?limit=2&offset=3")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["total"] == 5
+    assert len(data["events"]) == 2
+    assert data["offset"] == 3
+    assert data["events"][0]["type"] == "page.test.3"
+    assert data["events"][1]["type"] == "page.test.4"
+
+
+def test_list_events_pagination_offset_beyond(client):
+    for i in range(3):
+        client.post(
+            "/api/events",
+            data=json.dumps({"type": f"page.test.{i}"}),
+            content_type="application/json",
+        )
+    resp = client.get("/api/events?limit=10&offset=10")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["total"] == 3
+    assert len(data["events"]) == 0
+
+
+def test_list_events_pagination_with_filter(client):
+    for i in range(4):
+        client.post(
+            "/api/events",
+            data=json.dumps({"type": "target"}),
+            content_type="application/json",
+        )
+    client.post(
+        "/api/events",
+        data=json.dumps({"type": "other"}),
+        content_type="application/json",
+    )
+    resp = client.get("/api/events?type=target&limit=2&offset=1")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["total"] == 4
+    assert len(data["events"]) == 2
+
+
+def test_list_events_negative_limit(client):
+    client.post(
+        "/api/events",
+        data=json.dumps({"type": "neg.test"}),
+        content_type="application/json",
+    )
+    resp = client.get("/api/events?limit=-1")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["total"] == 1
+    assert len(data["events"]) == 1
+
+
+def test_list_events_negative_offset(client):
+    client.post(
+        "/api/events",
+        data=json.dumps({"type": "neg.test"}),
+        content_type="application/json",
+    )
+    resp = client.get("/api/events?offset=-5")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["offset"] == 0
 
 
 def test_get_event_not_found(client):
@@ -188,8 +282,8 @@ def test_events_store_max_capacity(client, monkeypatch):
         )
     resp = client.get("/api/events")
     data = resp.get_json()
-    assert len(data) == 3
-    types = [e["type"] for e in data]
+    assert data["total"] == 3
+    types = [e["type"] for e in data["events"]]
     assert "cap.test.0" not in types
     assert "cap.test.1" not in types
     assert "cap.test.4" in types


### PR DESCRIPTION
## 変更概要

- `GET /api/events` に `limit`（デフォルト: 50）と `offset`（デフォルト: 0）パラメータを追加
- レスポンス形式を `{events, total, limit, offset}` に変更し、全件数を返却
- 既存の `type` フィルターとの併用に対応
- 負の値に対する安全なフォールバック処理を追加
- ページネーション関連テスト6件を追加

Closes #8

## 動作確認手順

1. `cd gateway && pip install -r requirements.txt`
2. `pytest -v` で全テストがパスすることを確認
3. `GET /api/events?limit=2&offset=0` でページネーションが動作することを確認