### PR TITLE
fix: Dashboard の Events/Timeline プロキシを修正

### DIFF
--- a/dashboard/src/index.test.ts
+++ b/dashboard/src/index.test.ts
@@ -1,5 +1,9 @@
 import request from "supertest";
+import axios from "axios";
 import app from "./index";
+
+jest.mock("axios");
+const mockedAxios = axios as jest.Mocked<typeof axios>;
 
 describe("Dashboard Service", () => {
   describe("GET /health", () => {
@@ -14,16 +18,74 @@ describe("Dashboard Service", () => {
 
   describe("GET /api/dashboard", () => {
     it("should return a dashboard snapshot", async () => {
+      mockedAxios.get.mockResolvedValueOnce({
+        data: { total: 5, by_status: {}, by_type: {} },
+        status: 200,
+        statusText: "OK",
+        headers: {},
+        config: {} as never,
+      });
       const res = await request(app).get("/api/dashboard");
       expect(res.status).toBe(200);
       expect(res.body.service).toBe("dashboard");
       expect(res.body.generated_at).toBeDefined();
       expect(res.body.gateway_stats).toBeDefined();
     });
+
+    it("should handle gateway unreachable", async () => {
+      mockedAxios.get.mockRejectedValueOnce(new Error("ECONNREFUSED"));
+      const res = await request(app).get("/api/dashboard");
+      expect(res.status).toBe(200);
+      expect(res.body.gateway_stats).toEqual({ error: "Gateway unreachable" });
+    });
   });
 
   describe("GET /api/events", () => {
+    it("should proxy events from gateway", async () => {
+      mockedAxios.get.mockResolvedValueOnce({
+        data: { events: [{ type: "test" }], total: 1, limit: 50, offset: 0 },
+        status: 200,
+        statusText: "OK",
+        headers: {},
+        config: {} as never,
+      });
+      const res = await request(app).get("/api/events");
+      expect(res.status).toBe(200);
+      expect(res.body.events).toHaveLength(1);
+      expect(res.body.total).toBe(1);
+    });
+
+    it("should forward type query parameter", async () => {
+      mockedAxios.get.mockResolvedValueOnce({
+        data: { events: [], total: 0, limit: 50, offset: 0 },
+        status: 200,
+        statusText: "OK",
+        headers: {},
+        config: {} as never,
+      });
+      await request(app).get("/api/events?type=user.signup");
+      expect(mockedAxios.get).toHaveBeenCalledWith(
+        expect.stringContaining("type=user.signup"),
+        expect.any(Object)
+      );
+    });
+
+    it("should forward limit and offset query parameters", async () => {
+      mockedAxios.get.mockResolvedValueOnce({
+        data: { events: [], total: 0, limit: 10, offset: 5 },
+        status: 200,
+        statusText: "OK",
+        headers: {},
+        config: {} as never,
+      });
+      await request(app).get("/api/events?limit=10&offset=5");
+      const calledUrl = mockedAxios.get.mock.calls[mockedAxios.get.mock.calls.length - 1][0];
+      expect(calledUrl).toContain("limit=10");
+      expect(calledUrl).toContain("offset=5");
+    });
+
     it("should return 502 when gateway is unreachable", async () => {
+      mockedAxios.get.mockRejectedValueOnce(new Error("ECONNREFUSED"));
       const res = await request(app).get("/api/events");
       expect(res.status).toBe(502);
       expect(res.body.error).toBeDefined();
@@ -31,7 +93,33 @@ describe("Dashboard Service", () => {
   });
 
   describe("GET /api/timeline", () => {
+    it("should build timeline from gateway events", async () => {
+      const now = Date.now() / 1000;
+      mockedAxios.get.mockResolvedValueOnce({
+        data: {
+          events: [
+            { timestamp: now, type: "test", status: "received" },
+            { timestamp: now, type: "test", status: "received" },
+          ],
+          total: 2,
+          limit: 50,
+          offset: 0,
+        },
+        status: 200,
+        statusText: "OK",
+        headers: {},
+        config: {} as never,
+      });
+      const res = await request(app).get("/api/timeline");
+      expect(res.status).toBe(200);
+      expect(Array.isArray(res.body)).toBe(true);
+      expect(res.body[0]).toHaveProperty("hour");
+      expect(res.body[0]).toHaveProperty("count");
+      expect(res.body[0].count).toBe(2);
+    });
+
     it("should return 502 when gateway is unreachable", async () => {
+      mockedAxios.get.mockRejectedValueOnce(new Error("ECONNREFUSED"));
       const res = await request(app).get("/api/timeline");
       expect(res.status).toBe(502);
       expect(res.body.error).toBeDefined();

--- a/dashboard/src/index.ts
+++ b/dashboard/src/index.ts
@@ -53,11 +53,14 @@ app.get("/api/dashboard", async (_req: Request, res: Response) => {
 
 app.get("/api/events", async (req: Request, res: Response) => {
   try {
-    const params = req.query.type ? `?type=${req.query.type}` : "";
-    const resp = await axios.get(`${GATEWAY_URL}/api/events${params}`, {
-      timeout: 5000,
-    });
-    log("info", `Fetched ${resp.data.length} events from gateway`);
+    const params = new URLSearchParams();
+    if (req.query.type) params.set("type", String(req.query.type));
+    if (req.query.limit) params.set("limit", String(req.query.limit));
+    if (req.query.offset) params.set("offset", String(req.query.offset));
+    const qs = params.toString();
+    const url = qs ? `${GATEWAY_URL}/api/events?${qs}` : `${GATEWAY_URL}/api/events`;
+    const resp = await axios.get(url, { timeout: 5000 });
+    log("info", `Fetched events from gateway (total: ${resp.data.total})`);
     res.json(resp.data);
   } catch (err) {
     log("error", `Failed to fetch events: ${err}`);
@@ -71,7 +74,7 @@ app.get("/api/timeline", async (_req: Request, res: Response) => {
       timeout: 5000,
     });
     const events: Array<{ timestamp: number; type: string; status: string }> =
-      resp.data;
+      resp.data.events;
 
     const buckets: Record<string, number> = {};
     for (const event of events) {


### PR DESCRIPTION
## 変更概要

- `/api/events` プロキシに `limit`・`offset` クエリパラメータの転送を追加
- `/api/timeline` で Gateway のレスポンス形式（`resp.data.events`）を正しく参照するよう修正
- axios mock を使ったテストを拡充（9テストケース）

Closes #10

## 動作確認手順

1. `cd dashboard && npm test` を実行し全テストが通ることを確認
2. `npm run lint` でリントエラーがないことを確認