### PR TITLE
fix: processorテストの状態汚染修正とgateway本番サーバー改善

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ test: test-python test-go test-ts
 	@echo "All tests passed!"
 
 test-python:
-	cd gateway && pip install -r requirements.txt -q && pytest -v
+	cd gateway && pip install -r requirements-dev.txt -q && pytest -v
 
 test-go:
 	cd processor && go test -v ./...
@@ -16,7 +16,7 @@ lint: lint-python lint-go lint-ts
 	@echo "All lints passed!"
 
 lint-python:
-	cd gateway && flake8 --max-line-length=120 --exclude=__pycache__ .
+	cd gateway && pip install -r requirements-dev.txt -q && flake8 --max-line-length=120 --exclude=__pycache__ .
 
 lint-go:
 	cd processor && go vet ./...

--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -9,4 +9,4 @@ COPY . .
 
 EXPOSE 8080
 
-CMD ["python", "app.py"]
+CMD ["gunicorn", "--bind", "0.0.0.0:8080", "--workers", "2", "--access-logfile", "-", "app:app"]

--- a/gateway/requirements-dev.txt
+++ b/gateway/requirements-dev.txt
@@ -1,0 +1,3 @@
+-r requirements.txt
+pytest==8.3.4
+flake8==7.1.1

--- a/gateway/requirements.txt
+++ b/gateway/requirements.txt
@@ -1,5 +1,4 @@
 flask==3.1.0
 flask-cors==5.0.0
 requests==2.32.3
-pytest==8.3.4
-flake8==7.1.1
+gunicorn==23.0.0

--- a/processor/main_test.go
+++ b/processor/main_test.go
@@ -8,6 +8,12 @@ import (
 	"testing"
 )
 
+func resetProcessedEvents() {
+	mu.Lock()
+	processedEvents = nil
+	mu.Unlock()
+}
+
 func TestHealthHandler(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/health", nil)
 	w := httptest.NewRecorder()
@@ -29,6 +35,8 @@ func TestHealthHandler(t *testing.T) {
 }
 
 func TestProcessHandler_Success(t *testing.T) {
+	resetProcessedEvents()
+
 	event := Event{
 		ID:      "test-123",
 		Type:    "user.signup",
@@ -55,6 +63,8 @@ func TestProcessHandler_Success(t *testing.T) {
 }
 
 func TestProcessHandler_HighPriority(t *testing.T) {
+	resetProcessedEvents()
+
 	event := Event{ID: "err-1", Type: "system.error"}
 	body, _ := json.Marshal(event)
 	req := httptest.NewRequest(http.MethodPost, "/process", bytes.NewReader(body))
@@ -70,6 +80,8 @@ func TestProcessHandler_HighPriority(t *testing.T) {
 }
 
 func TestProcessHandler_LowPriority(t *testing.T) {
+	resetProcessedEvents()
+
 	event := Event{ID: "info-1", Type: "system.info"}
 	body, _ := json.Marshal(event)
 	req := httptest.NewRequest(http.MethodPost, "/process", bytes.NewReader(body))
@@ -156,6 +168,8 @@ func TestClassifyPriority(t *testing.T) {
 }
 
 func TestStatsHandler(t *testing.T) {
+	resetProcessedEvents()
+
 	req := httptest.NewRequest(http.MethodGet, "/stats", nil)
 	w := httptest.NewRecorder()
 	statsHandler(w, req)
@@ -167,7 +181,7 @@ func TestStatsHandler(t *testing.T) {
 	var stats Stats
 	json.NewDecoder(w.Body).Decode(&stats)
 
-	if stats.TotalProcessed < 0 {
-		t.Fatal("total_processed should be >= 0")
+	if stats.TotalProcessed != 0 {
+		t.Fatalf("expected 0 total_processed after reset, got %d", stats.TotalProcessed)
 	}
 }


### PR DESCRIPTION
## 変更概要

- `processor/main_test.go` に `resetProcessedEvents()` を追加し、各テストで状態をリセットするよう修正
- gateway に gunicorn を追加し、Dockerfile の CMD を `gunicorn` に変更
- `requirements-dev.txt` を新規作成してテスト依存(pytest, flake8)を分離
- Makefile の test-python/lint ターゲットを `requirements-dev.txt` に対応

Closes #12

## 動作確認手順

1. `cd processor && go test -v ./...` で全10テストがパス
2. `cd gateway && pip install -r requirements-dev.txt && pytest -v` で全22テストがパス
3. `make lint` で lint が通る
4. `docker compose build` でビルドが成功する