### PR TITLE
feat: processorのイベントストアに上限を追加しテストカバレッジを向上

### DIFF
--- a/processor/main.go
+++ b/processor/main.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -37,10 +38,17 @@ var (
 	processedEvents []ProcessResult
 	mu              sync.Mutex
 	logger          *log.Logger
+	maxProcessed    int
 )
 
 func init() {
 	logger = log.New(os.Stdout, "[processor] ", log.LstdFlags)
+	maxProcessed = 10000
+	if v := os.Getenv("PROCESSOR_MAX_EVENTS"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			maxProcessed = n
+		}
+	}
 }
 
 func classifyPriority(eventType string) string {
@@ -101,6 +109,11 @@ func processHandler(w http.ResponseWriter, r *http.Request) {
 
 	mu.Lock()
 	processedEvents = append(processedEvents, result)
+	if len(processedEvents) > maxProcessed {
+		removed := len(processedEvents) - maxProcessed
+		processedEvents = processedEvents[removed:]
+		logger.Printf("Evicted %d old events (store capped at %d)", removed, maxProcessed)
+	}
 	mu.Unlock()
 
 	logger.Printf("Processed event: id=%s type=%s priority=%s", event.ID, event.Type, result.Priority)

--- a/processor/main_test.go
+++ b/processor/main_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -183,5 +184,105 @@ func TestStatsHandler(t *testing.T) {
 
 	if stats.TotalProcessed != 0 {
 		t.Fatalf("expected 0 total_processed after reset, got %d", stats.TotalProcessed)
+	}
+}
+
+func TestStatsHandler_AfterProcessing(t *testing.T) {
+	resetProcessedEvents()
+
+	events := []Event{
+		{ID: "e1", Type: "system.error", Payload: map[string]interface{}{"k": "v"}},
+		{ID: "e2", Type: "user.signup"},
+		{ID: "e3", Type: "page.view"},
+	}
+
+	for _, event := range events {
+		body, _ := json.Marshal(event)
+		req := httptest.NewRequest(http.MethodPost, "/process", bytes.NewReader(body))
+		w := httptest.NewRecorder()
+		processHandler(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d", w.Code)
+		}
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/stats", nil)
+	w := httptest.NewRecorder()
+	statsHandler(w, req)
+
+	var stats Stats
+	json.NewDecoder(w.Body).Decode(&stats)
+
+	if stats.TotalProcessed != 3 {
+		t.Fatalf("expected 3 total_processed, got %d", stats.TotalProcessed)
+	}
+	if stats.ByPriority["high"] != 1 {
+		t.Errorf("expected 1 high priority, got %d", stats.ByPriority["high"])
+	}
+	if stats.ByPriority["medium"] != 1 {
+		t.Errorf("expected 1 medium priority, got %d", stats.ByPriority["medium"])
+	}
+	if stats.ByPriority["low"] != 1 {
+		t.Errorf("expected 1 low priority, got %d", stats.ByPriority["low"])
+	}
+}
+
+func TestProcessedHandler(t *testing.T) {
+	resetProcessedEvents()
+
+	event := Event{ID: "ph-1", Type: "user.login"}
+	body, _ := json.Marshal(event)
+	req := httptest.NewRequest(http.MethodPost, "/process", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	processHandler(w, req)
+
+	req = httptest.NewRequest(http.MethodGet, "/processed", nil)
+	w = httptest.NewRecorder()
+	processedHandler(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	var results []ProcessResult
+	json.NewDecoder(w.Body).Decode(&results)
+
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if results[0].EventID != "ph-1" {
+		t.Errorf("expected event_id ph-1, got %s", results[0].EventID)
+	}
+}
+
+func TestProcessedEvents_MaxCapacity(t *testing.T) {
+	resetProcessedEvents()
+	oldMax := maxProcessed
+	maxProcessed = 3
+	defer func() { maxProcessed = oldMax }()
+
+	for i := 0; i < 5; i++ {
+		event := Event{ID: fmt.Sprintf("cap-%d", i), Type: "test.event"}
+		body, _ := json.Marshal(event)
+		req := httptest.NewRequest(http.MethodPost, "/process", bytes.NewReader(body))
+		w := httptest.NewRecorder()
+		processHandler(w, req)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/processed", nil)
+	w := httptest.NewRecorder()
+	processedHandler(w, req)
+
+	var results []ProcessResult
+	json.NewDecoder(w.Body).Decode(&results)
+
+	if len(results) != 3 {
+		t.Fatalf("expected 3 results (capped), got %d", len(results))
+	}
+	if results[0].EventID != "cap-2" {
+		t.Errorf("expected oldest remaining to be cap-2, got %s", results[0].EventID)
+	}
+	if results[2].EventID != "cap-4" {
+		t.Errorf("expected newest to be cap-4, got %s", results[2].EventID)
 	}
 }


### PR DESCRIPTION
## 変更概要

- `processedEvents` スライスに `PROCESSOR_MAX_EVENTS` 環境変数による上限を追加（デフォルト: 10000）
- 上限超過時に古いイベントをFIFOで自動削除（gateway の `MAX_EVENTS` と同じパターン）
- `TestStatsHandler_AfterProcessing`: 複数イベント処理後の統計値テスト追加
- `TestProcessedHandler`: 処理済みイベント一覧取得テスト追加
- `TestProcessedEvents_MaxCapacity`: ストア上限と古いイベント削除のテスト追加

Closes #14

## 動作確認手順

1. `cd processor && go test -v ./...` — 全13テストパス
2. `PROCESSOR_MAX_EVENTS=5` に設定して6件以上処理 → `/processed` で最新5件のみ返却