### PR TITLE
feat: processorにgraceful shutdownを追加し、gatewayにリクエストID追跡を導入

### DIFF
--- a/gateway/app.py
+++ b/gateway/app.py
@@ -3,7 +3,7 @@ import logging
 import time
 import uuid
 
-from flask import Flask, request, jsonify
+from flask import Flask, request, jsonify, g
 from flask_cors import CORS
 import requests
 
@@ -23,6 +23,27 @@ MAX_PAYLOAD_SIZE = int(os.environ.get("MAX_PAYLOAD_SIZE", str(1024 * 1024)))
 DEFAULT_PAGE_LIMIT = int(os.environ.get("DEFAULT_PAGE_LIMIT", "50"))
 
 events_store: list[dict] = []
+
+
+@app.before_request
+def assign_request_id():
+    incoming = request.headers.get("X-Request-ID", "")
+    if incoming:
+        g.request_id = incoming
+    else:
+        g.request_id = str(uuid.uuid4())
+    logger.info(
+        "request_id=%s method=%s path=%s",
+        g.request_id,
+        request.method,
+        request.path,
+    )
+
+
+@app.after_request
+def add_request_id_header(response):
+    response.headers["X-Request-ID"] = g.get("request_id", "")
+    return response
 
 
 @app.route("/health", methods=["GET"])

--- a/gateway/test_app.py
+++ b/gateway/test_app.py
@@ -1,4 +1,5 @@
 import json
+import uuid
 import pytest
 from app import app, events_store
 
@@ -310,3 +311,32 @@ def test_payload_within_limit(client, monkeypatch):
         content_type="application/json",
     )
     assert resp.status_code == 201
+
+
+def test_request_id_generated(client):
+    resp = client.get("/health")
+    assert resp.status_code == 200
+    request_id = resp.headers.get("X-Request-ID")
+    assert request_id is not None
+    uuid.UUID(request_id)
+
+
+def test_request_id_forwarded(client):
+    custom_id = "custom-trace-id-12345"
+    resp = client.get("/health", headers={"X-Request-ID": custom_id})
+    assert resp.status_code == 200
+    assert resp.headers.get("X-Request-ID") == custom_id
+
+
+def test_request_id_unique_per_request(client):
+    resp1 = client.get("/health")
+    resp2 = client.get("/health")
+    id1 = resp1.headers.get("X-Request-ID")
+    id2 = resp2.headers.get("X-Request-ID")
+    assert id1 != id2
+
+
+def test_request_id_on_error_response(client):
+    resp = client.get("/api/events/nonexistent-id")
+    assert resp.status_code == 404
+    assert resp.headers.get("X-Request-ID") is not None

--- a/processor/main.go
+++ b/processor/main.go
@@ -1,14 +1,17 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log"
 	"net/http"
 	"os"
+	"os/signal"
 	"strconv"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 )
 
@@ -39,6 +42,7 @@ var (
 	mu              sync.Mutex
 	logger          *log.Logger
 	maxProcessed    int
+	shutdownTimeout time.Duration
 )
 
 func init() {
@@ -47,6 +51,12 @@ func init() {
 	if v := os.Getenv("PROCESSOR_MAX_EVENTS"); v != "" {
 		if n, err := strconv.Atoi(v); err == nil && n > 0 {
 			maxProcessed = n
+		}
+	}
+	shutdownTimeout = 30 * time.Second
+	if v := os.Getenv("SHUTDOWN_TIMEOUT_SECONDS"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			shutdownTimeout = time.Duration(n) * time.Second
 		}
 	}
 }
@@ -163,8 +173,30 @@ func main() {
 	mux.HandleFunc("/stats", statsHandler)
 	mux.HandleFunc("/processed", processedHandler)
 
-	logger.Printf("Starting processor on port %s", port)
-	if err := http.ListenAndServe(":"+port, mux); err != nil {
-		logger.Fatalf("Server failed: %v", err)
+	srv := &http.Server{
+		Addr:    ":" + port,
+		Handler: mux,
 	}
+
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	go func() {
+		logger.Printf("Starting processor on port %s", port)
+		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			logger.Fatalf("Server failed: %v", err)
+		}
+	}()
+
+	<-ctx.Done()
+	stop()
+	logger.Println("Shutting down gracefully...")
+
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
+	defer cancel()
+
+	if err := srv.Shutdown(shutdownCtx); err != nil {
+		logger.Fatalf("Forced shutdown: %v", err)
+	}
+	logger.Println("Server stopped")
 }


### PR DESCRIPTION
## 変更概要
- **processor (Go)**: `signal.NotifyContext`を使ったgraceful shutdownを実装。SIGTERM/SIGINT受信時にリクエスト処理中の接続を安全に終了する。シャットダウンタイムアウトは`SHUTDOWN_TIMEOUT_SECONDS`環境変数で設定可能（デフォルト30秒）
- **gateway (Python)**: リクエストごとにUUID v4のX-Request-IDを生成し、ログとレスポンスヘッダに含める。クライアントから送信されたX-Request-IDがあればそれを優先
- テスト4件追加（X-Request-ID生成・転送・一意性・エラーレスポンス）

Closes #16

## 動作確認
- `flake8 --max-line-length=120 app.py` → PASS
- `pytest -v test_app.py` → 26 passed
- `go vet ./...` → OK
- `go test -v ./...` → 13 passed