### PR TITLE
fix: processor HTTPサーバーにタイムアウト設定とメソッド検証を追加

### DIFF
--- a/processor/main.go
+++ b/processor/main.go
@@ -38,12 +38,25 @@ type Stats struct {
 }
 
 var (
-	processedEvents []ProcessResult
-	mu              sync.Mutex
-	logger          *log.Logger
-	maxProcessed    int
-	shutdownTimeout time.Duration
+	processedEvents   []ProcessResult
+	mu                sync.Mutex
+	logger            *log.Logger
+	maxProcessed      int
+	shutdownTimeout   time.Duration
+	readHeaderTimeout time.Duration
+	readTimeout       time.Duration
+	writeTimeout      time.Duration
+	idleTimeout       time.Duration
 )
+
+func envSeconds(key string, fallback time.Duration) time.Duration {
+	if v := os.Getenv(key); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			return time.Duration(n) * time.Second
+		}
+	}
+	return fallback
+}
 
 func init() {
 	logger = log.New(os.Stdout, "[processor] ", log.LstdFlags)
@@ -53,12 +66,22 @@ func init() {
 			maxProcessed = n
 		}
 	}
-	shutdownTimeout = 30 * time.Second
-	if v := os.Getenv("SHUTDOWN_TIMEOUT_SECONDS"); v != "" {
-		if n, err := strconv.Atoi(v); err == nil && n > 0 {
-			shutdownTimeout = time.Duration(n) * time.Second
+	shutdownTimeout = envSeconds("SHUTDOWN_TIMEOUT_SECONDS", 30*time.Second)
+	readHeaderTimeout = envSeconds("PROCESSOR_READ_HEADER_TIMEOUT", 5*time.Second)
+	readTimeout = envSeconds("PROCESSOR_READ_TIMEOUT", 15*time.Second)
+	writeTimeout = envSeconds("PROCESSOR_WRITE_TIMEOUT", 15*time.Second)
+	idleTimeout = envSeconds("PROCESSOR_IDLE_TIMEOUT", 60*time.Second)
+}
+
+func methodAllowed(w http.ResponseWriter, r *http.Request, allowed ...string) bool {
+	for _, m := range allowed {
+		if r.Method == m {
+			return true
 		}
 	}
+	w.Header().Set("Allow", strings.Join(allowed, ", "))
+	http.Error(w, `{"error":"method not allowed"}`, http.StatusMethodNotAllowed)
+	return false
 }
 
 func classifyPriority(eventType string) string {
@@ -82,6 +105,9 @@ func generateTags(event Event) []string {
 }
 
 func healthHandler(w http.ResponseWriter, r *http.Request) {
+	if !methodAllowed(w, r, http.MethodGet, http.MethodHead) {
+		return
+	}
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(map[string]interface{}{
 		"status":    "healthy",
@@ -91,8 +117,7 @@ func healthHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func processHandler(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodPost {
-		http.Error(w, `{"error":"method not allowed"}`, http.StatusMethodNotAllowed)
+	if !methodAllowed(w, r, http.MethodPost) {
 		return
 	}
 
@@ -133,6 +158,10 @@ func processHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func statsHandler(w http.ResponseWriter, r *http.Request) {
+	if !methodAllowed(w, r, http.MethodGet, http.MethodHead) {
+		return
+	}
+
 	mu.Lock()
 	defer mu.Unlock()
 
@@ -154,6 +183,10 @@ func statsHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func processedHandler(w http.ResponseWriter, r *http.Request) {
+	if !methodAllowed(w, r, http.MethodGet, http.MethodHead) {
+		return
+	}
+
 	mu.Lock()
 	defer mu.Unlock()
 
@@ -174,8 +207,12 @@ func main() {
 	mux.HandleFunc("/processed", processedHandler)
 
 	srv := &http.Server{
-		Addr:    ":" + port,
-		Handler: mux,
+		Addr:              ":" + port,
+		Handler:           mux,
+		ReadHeaderTimeout: readHeaderTimeout,
+		ReadTimeout:       readTimeout,
+		WriteTimeout:      writeTimeout,
+		IdleTimeout:       idleTimeout,
 	}
 
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)

--- a/processor/main_test.go
+++ b/processor/main_test.go
@@ -6,7 +6,9 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
+	"time"
 )
 
 func resetProcessedEvents() {
@@ -284,5 +286,61 @@ func TestProcessedEvents_MaxCapacity(t *testing.T) {
 	}
 	if results[2].EventID != "cap-4" {
 		t.Errorf("expected newest to be cap-4, got %s", results[2].EventID)
+	}
+}
+
+func TestStatsHandler_MethodNotAllowed(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/stats", nil)
+	w := httptest.NewRecorder()
+	statsHandler(w, req)
+
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("expected 405, got %d", w.Code)
+	}
+	if allow := w.Header().Get("Allow"); allow == "" {
+		t.Errorf("expected Allow header to be set, got empty")
+	}
+}
+
+func TestProcessedHandler_MethodNotAllowed(t *testing.T) {
+	req := httptest.NewRequest(http.MethodDelete, "/processed", nil)
+	w := httptest.NewRecorder()
+	processedHandler(w, req)
+
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("expected 405, got %d", w.Code)
+	}
+}
+
+func TestHealthHandler_MethodNotAllowed(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPut, "/health", nil)
+	w := httptest.NewRecorder()
+	healthHandler(w, req)
+
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("expected 405, got %d", w.Code)
+	}
+}
+
+func TestEnvSeconds_OverrideAndFallback(t *testing.T) {
+	const key = "TEST_PROCESSOR_ENV_SECONDS"
+	os.Unsetenv(key)
+	if got := envSeconds(key, 7*time.Second); got != 7*time.Second {
+		t.Fatalf("expected fallback 7s, got %v", got)
+	}
+
+	t.Setenv(key, "42")
+	if got := envSeconds(key, 7*time.Second); got != 42*time.Second {
+		t.Fatalf("expected override 42s, got %v", got)
+	}
+
+	t.Setenv(key, "not-a-number")
+	if got := envSeconds(key, 7*time.Second); got != 7*time.Second {
+		t.Fatalf("expected fallback for invalid value, got %v", got)
+	}
+
+	t.Setenv(key, "0")
+	if got := envSeconds(key, 7*time.Second); got != 7*time.Second {
+		t.Fatalf("expected fallback for zero value, got %v", got)
 	}
 }


### PR DESCRIPTION
## 概要

- `processor/main.go` の `http.Server` に `ReadHeaderTimeout=5s` / `ReadTimeout=15s` / `WriteTimeout=15s` / `IdleTimeout=60s` を追加（Slowloris・接続放置による goroutine / FD 枯渇対策）
- 各タイムアウトは `PROCESSOR_READ_HEADER_TIMEOUT` / `PROCESSOR_READ_TIMEOUT` / `PROCESSOR_WRITE_TIMEOUT` / `PROCESSOR_IDLE_TIMEOUT`（秒指定）で上書き可能
- `/health` / `/stats` / `/processed` で GET / HEAD 以外のメソッドを 405 で拒否（`Allow` ヘッダ付与）
- `methodAllowed` ヘルパで重複ロジックを集約
- 環境変数のパースを共通化する `envSeconds` を追加

Closes #20

## 動作確認手順

```bash
cd processor
go vet ./...
go test -race ./...
```

- 既存テストはすべてパス
- 追加テスト：
  - `TestStatsHandler_MethodNotAllowed`（POST→405、Allow ヘッダ確認）
  - `TestProcessedHandler_MethodNotAllowed`（DELETE→405）
  - `TestHealthHandler_MethodNotAllowed`（PUT→405）
  - `TestEnvSeconds_OverrideAndFallback`（環境変数の上書き・フォールバック・無効値処理）
