### PR TITLE
feat: gateway GET /api/events に status フィルタを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ npm start
 |--------|----------|-------------|
 | GET | `/health` | Health check |
 | POST | `/api/events` | Create a new event |
-| GET | `/api/events` | List events (optional `?type=` filter) |
+| GET | `/api/events` | List events (optional `?type=`, `?status=`, `?limit=`, `?offset=` filters) |
 | GET | `/api/events/:id` | Get event by ID |
 | GET | `/api/stats` | Get aggregated statistics |
 
@@ -111,6 +111,19 @@ Response:
     "summary": "Processed event 'user.signup' with priority 'medium'"
   }
 }
+```
+
+#### List events with filters
+
+```bash
+# Filter by event type
+curl "http://localhost:8080/api/events?type=user.signup"
+
+# Filter by processing status (received | processed | process_failed | process_error)
+curl "http://localhost:8080/api/events?status=process_failed"
+
+# Combine type + status filters
+curl "http://localhost:8080/api/events?type=user.signup&status=processed"
 ```
 
 ### Processor (port 8081)

--- a/dashboard/src/index.test.ts
+++ b/dashboard/src/index.test.ts
@@ -84,6 +84,19 @@ describe("Dashboard Service", () => {
       expect(calledUrl).toContain("offset=5");
     });
 
+    it("should forward status query parameter", async () => {
+      mockedAxios.get.mockResolvedValueOnce({
+        data: { events: [], total: 0, limit: 50, offset: 0 },
+        status: 200,
+        statusText: "OK",
+        headers: {},
+        config: {} as never,
+      });
+      await request(app).get("/api/events?status=process_failed");
+      const calledUrl = mockedAxios.get.mock.calls[mockedAxios.get.mock.calls.length - 1][0];
+      expect(calledUrl).toContain("status=process_failed");
+    });
+
     it("should return 502 when gateway is unreachable", async () => {
       mockedAxios.get.mockRejectedValueOnce(new Error("ECONNREFUSED"));
       const res = await request(app).get("/api/events");

--- a/dashboard/src/index.ts
+++ b/dashboard/src/index.ts
@@ -55,6 +55,7 @@ app.get("/api/events", async (req: Request, res: Response) => {
   try {
     const params = new URLSearchParams();
     if (req.query.type) params.set("type", String(req.query.type));
+    if (req.query.status) params.set("status", String(req.query.status));
     if (req.query.limit) params.set("limit", String(req.query.limit));
     if (req.query.offset) params.set("offset", String(req.query.offset));
     const qs = params.toString();

--- a/gateway/app.py
+++ b/gateway/app.py
@@ -22,6 +22,8 @@ MAX_EVENTS = int(os.environ.get("MAX_EVENTS", "10000"))
 MAX_PAYLOAD_SIZE = int(os.environ.get("MAX_PAYLOAD_SIZE", str(1024 * 1024)))
 DEFAULT_PAGE_LIMIT = int(os.environ.get("DEFAULT_PAGE_LIMIT", "50"))
 
+ALLOWED_STATUSES = {"received", "processed", "process_failed", "process_error"}
+
 events_store: list[dict] = []
 
 
@@ -107,8 +109,16 @@ def create_event():
 @app.route("/api/events", methods=["GET"])
 def list_events():
     event_type = request.args.get("type")
+    status = request.args.get("status")
     limit = request.args.get("limit", DEFAULT_PAGE_LIMIT, type=int)
     offset = request.args.get("offset", 0, type=int)
+
+    if status is not None and status not in ALLOWED_STATUSES:
+        logger.warning("Invalid status filter: %s", status)
+        return jsonify({
+            "error": "Invalid status",
+            "allowed": sorted(ALLOWED_STATUSES),
+        }), 400
 
     if limit < 0:
         limit = DEFAULT_PAGE_LIMIT
@@ -117,7 +127,9 @@ def list_events():
 
     filtered = events_store
     if event_type:
-        filtered = [e for e in events_store if e["type"] == event_type]
+        filtered = [e for e in filtered if e["type"] == event_type]
+    if status:
+        filtered = [e for e in filtered if e.get("status") == status]
 
     total = len(filtered)
     paginated = filtered[offset:offset + limit]

--- a/gateway/test_app.py
+++ b/gateway/test_app.py
@@ -182,6 +182,63 @@ def test_list_events_negative_offset(client):
     assert data["offset"] == 0
 
 
+def test_list_events_filter_by_status(client):
+    create_resp = client.post(
+        "/api/events",
+        data=json.dumps({"type": "status.test"}),
+        content_type="application/json",
+    )
+    assert create_resp.status_code == 201
+    created_status = create_resp.get_json()["status"]
+
+    resp = client.get(f"/api/events?status={created_status}")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["total"] >= 1
+    for e in data["events"]:
+        assert e["status"] == created_status
+
+
+def test_list_events_filter_by_status_no_match(client):
+    client.post(
+        "/api/events",
+        data=json.dumps({"type": "status.nomatch"}),
+        content_type="application/json",
+    )
+    resp = client.get("/api/events?status=received")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    for e in data["events"]:
+        assert e["status"] == "received"
+
+
+def test_list_events_invalid_status(client):
+    resp = client.get("/api/events?status=bogus")
+    assert resp.status_code == 400
+    data = resp.get_json()
+    assert "allowed" in data
+    assert "received" in data["allowed"]
+
+
+def test_list_events_status_combined_with_type(client):
+    client.post(
+        "/api/events",
+        data=json.dumps({"type": "alpha"}),
+        content_type="application/json",
+    )
+    client.post(
+        "/api/events",
+        data=json.dumps({"type": "beta"}),
+        content_type="application/json",
+    )
+    resp = client.get("/api/events?type=alpha&status=process_error")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    for e in data["events"]:
+        assert e["type"] == "alpha"
+        assert e["status"] == "process_error"
+
+
 def test_get_event_not_found(client):
     resp = client.get("/api/events/nonexistent-id")
     assert resp.status_code == 404


### PR DESCRIPTION
## 変更概要

- `gateway/app.py`: `list_events` に `status` クエリパラメータを追加
  - 許可値: `received` / `processed` / `process_failed` / `process_error`
  - 不正値は 400 Bad Request（許可値リストをエラー本体で返却）
  - 既存の `type` フィルタと AND で組み合わせ可能
- `dashboard/src/index.ts`: `/api/events` で `status` クエリを gateway に forward
- `gateway/test_app.py`: status フィルタの正常系・エラー系・組合せの 4 ケースを追加（既存 26 → 30 ケース）
- `dashboard/src/index.test.ts`: status forward のテストを追加（既存 9 → 10 ケース）
- `README.md`: API リファレンスのテーブルとサンプルを更新

## 対応 Issue

Closes #24

## 動作確認

- [x] gateway: `pytest test_app.py` 30 件 pass
- [x] gateway: `flake8 --max-line-length=120 app.py test_app.py` クリーン
- [x] dashboard: `npm test` 10 件 pass
- [x] dashboard: `npx eslint src/` クリーン
- [x] dashboard: `npx tsc --noEmit` クリーン

## 動作例

```bash
# 処理失敗イベントだけ取得
curl 'http://localhost:8080/api/events?status=process_failed'

# type と組み合わせ
curl 'http://localhost:8080/api/events?type=user.signup&status=processed'

# 不正値
curl 'http://localhost:8080/api/events?status=bogus'
# => 400 {"error":"Invalid status","allowed":["process_error","process_failed","processed","received"]}
```