### PR TITLE
feat: GET /api/events に時系列フィルタ (since/until) と MAX_PAGE_LIMIT 上限を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ npm start
 |--------|----------|-------------|
 | GET | `/health` | Health check |
 | POST | `/api/events` | Create a new event |
-| GET | `/api/events` | List events (optional `?type=`, `?status=`, `?limit=`, `?offset=` filters) |
+| GET | `/api/events` | List events (optional `?type=`, `?status=`, `?since=`, `?until=`, `?limit=`, `?offset=` filters) |
 | GET | `/api/events/:id` | Get event by ID |
 | GET | `/api/stats` | Get aggregated statistics |
 
@@ -124,7 +124,12 @@ curl "http://localhost:8080/api/events?status=process_failed"
 
 # Combine type + status filters
 curl "http://localhost:8080/api/events?type=user.signup&status=processed"
+
+# Filter by time range (Unix timestamp seconds)
+curl "http://localhost:8080/api/events?since=1700000000&until=1700100000"
 ```
+
+> **Note**: `limit` is automatically clamped to `MAX_PAGE_LIMIT` (default 500). Invalid `since` / `until` (non-numeric, negative, or `until < since`) return `400`.
 
 ### Processor (port 8081)
 
@@ -182,6 +187,10 @@ All services are configured via environment variables. See [`.env.example`](.env
 | `LOG_LEVEL` | `INFO` | Log verbosity (DEBUG, INFO, WARNING, ERROR) |
 | `PROCESSOR_MAX_EVENTS` | `10000` | Max processed events kept in memory (processor) |
 | `PROCESSED_DEFAULT_LIMIT` | `50` | Default `limit` for `GET /processed` (processor) |
+| `MAX_EVENTS` | `10000` | Max events kept in memory (gateway) |
+| `MAX_PAYLOAD_SIZE` | `1048576` | Max request body size in bytes (gateway) |
+| `DEFAULT_PAGE_LIMIT` | `50` | Default `limit` for `GET /api/events` (gateway) |
+| `MAX_PAGE_LIMIT` | `500` | Upper bound for `limit` on `GET /api/events` (gateway) |
 
 ## Testing
 

--- a/gateway/app.py
+++ b/gateway/app.py
@@ -21,6 +21,7 @@ DASHBOARD_URL = os.environ.get("DASHBOARD_URL", "http://localhost:3000")
 MAX_EVENTS = int(os.environ.get("MAX_EVENTS", "10000"))
 MAX_PAYLOAD_SIZE = int(os.environ.get("MAX_PAYLOAD_SIZE", str(1024 * 1024)))
 DEFAULT_PAGE_LIMIT = int(os.environ.get("DEFAULT_PAGE_LIMIT", "50"))
+MAX_PAGE_LIMIT = int(os.environ.get("MAX_PAGE_LIMIT", "500"))
 
 ALLOWED_STATUSES = {"received", "processed", "process_failed", "process_error"}
 
@@ -106,12 +107,24 @@ def create_event():
     return jsonify(event), 201
 
 
+def _parse_timestamp_arg(value: str, name: str):
+    try:
+        ts = float(value)
+    except (TypeError, ValueError):
+        raise ValueError(f"'{name}' must be a numeric Unix timestamp")
+    if ts < 0:
+        raise ValueError(f"'{name}' must be non-negative")
+    return ts
+
+
 @app.route("/api/events", methods=["GET"])
 def list_events():
     event_type = request.args.get("type")
     status = request.args.get("status")
     limit = request.args.get("limit", DEFAULT_PAGE_LIMIT, type=int)
     offset = request.args.get("offset", 0, type=int)
+    since_raw = request.args.get("since")
+    until_raw = request.args.get("until")
 
     if status is not None and status not in ALLOWED_STATUSES:
         logger.warning("Invalid status filter: %s", status)
@@ -120,8 +133,25 @@ def list_events():
             "allowed": sorted(ALLOWED_STATUSES),
         }), 400
 
+    since = None
+    until = None
+    try:
+        if since_raw is not None:
+            since = _parse_timestamp_arg(since_raw, "since")
+        if until_raw is not None:
+            until = _parse_timestamp_arg(until_raw, "until")
+    except ValueError as e:
+        logger.warning("Invalid timestamp filter: %s", e)
+        return jsonify({"error": str(e)}), 400
+
+    if since is not None and until is not None and until < since:
+        logger.warning("Invalid range: until=%s < since=%s", until, since)
+        return jsonify({"error": "'until' must be greater than or equal to 'since'"}), 400
+
     if limit < 0:
         limit = DEFAULT_PAGE_LIMIT
+    if limit > MAX_PAGE_LIMIT:
+        limit = MAX_PAGE_LIMIT
     if offset < 0:
         offset = 0
 
@@ -130,6 +160,10 @@ def list_events():
         filtered = [e for e in filtered if e["type"] == event_type]
     if status:
         filtered = [e for e in filtered if e.get("status") == status]
+    if since is not None:
+        filtered = [e for e in filtered if e.get("timestamp", 0) >= since]
+    if until is not None:
+        filtered = [e for e in filtered if e.get("timestamp", 0) <= until]
 
     total = len(filtered)
     paginated = filtered[offset:offset + limit]

--- a/gateway/test_app.py
+++ b/gateway/test_app.py
@@ -370,6 +370,102 @@ def test_payload_within_limit(client, monkeypatch):
     assert resp.status_code == 201
 
 
+def test_list_events_filter_since(client):
+    client.post(
+        "/api/events",
+        data=json.dumps({"type": "ts.test"}),
+        content_type="application/json",
+    )
+    # All events should be present when since is in the past
+    resp = client.get("/api/events?since=0")
+    assert resp.status_code == 200
+    assert resp.get_json()["total"] == 1
+
+    # since far in the future returns nothing
+    resp = client.get("/api/events?since=99999999999")
+    assert resp.status_code == 200
+    assert resp.get_json()["total"] == 0
+
+
+def test_list_events_filter_until(client):
+    client.post(
+        "/api/events",
+        data=json.dumps({"type": "ts.test"}),
+        content_type="application/json",
+    )
+    # until far in the future includes everything
+    resp = client.get("/api/events?until=99999999999")
+    assert resp.status_code == 200
+    assert resp.get_json()["total"] == 1
+
+    # until in the past excludes everything
+    resp = client.get("/api/events?until=0")
+    assert resp.status_code == 200
+    assert resp.get_json()["total"] == 0
+
+
+def test_list_events_filter_since_and_until_combined(client):
+    client.post(
+        "/api/events",
+        data=json.dumps({"type": "ts.combo"}),
+        content_type="application/json",
+    )
+    resp = client.get("/api/events?since=0&until=99999999999")
+    assert resp.status_code == 200
+    assert resp.get_json()["total"] == 1
+
+
+def test_list_events_invalid_since(client):
+    resp = client.get("/api/events?since=notanumber")
+    assert resp.status_code == 400
+    assert "since" in resp.get_json()["error"]
+
+
+def test_list_events_negative_since(client):
+    resp = client.get("/api/events?since=-1")
+    assert resp.status_code == 400
+
+
+def test_list_events_invalid_until(client):
+    resp = client.get("/api/events?until=abc")
+    assert resp.status_code == 400
+    assert "until" in resp.get_json()["error"]
+
+
+def test_list_events_until_before_since(client):
+    resp = client.get("/api/events?since=100&until=50")
+    assert resp.status_code == 400
+    assert "until" in resp.get_json()["error"].lower()
+
+
+def test_list_events_limit_capped_at_max(client, monkeypatch):
+    monkeypatch.setattr("app.MAX_PAGE_LIMIT", 5)
+    for i in range(10):
+        client.post(
+            "/api/events",
+            data=json.dumps({"type": f"cap.{i}"}),
+            content_type="application/json",
+        )
+    resp = client.get("/api/events?limit=100")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["limit"] == 5
+    assert len(data["events"]) == 5
+    assert data["total"] == 10
+
+
+def test_list_events_limit_under_max_unaffected(client, monkeypatch):
+    monkeypatch.setattr("app.MAX_PAGE_LIMIT", 100)
+    client.post(
+        "/api/events",
+        data=json.dumps({"type": "norm"}),
+        content_type="application/json",
+    )
+    resp = client.get("/api/events?limit=10")
+    assert resp.status_code == 200
+    assert resp.get_json()["limit"] == 10
+
+
 def test_request_id_generated(client):
     resp = client.get("/health")
     assert resp.status_code == 200


### PR DESCRIPTION
## 概要

- `GET /api/events` に `since` / `until` クエリパラメータ（Unix タイムスタンプ秒）を追加し、時間範囲でのイベント検索を可能にした
- `MAX_PAGE_LIMIT` 環境変数（デフォルト 500）を追加し、過大な `limit` リクエストを上限値にクランプ
- 不正値（非数値・負値・`until < since`）は 400 で拒否
- `since` / `until` 周りで 9 件のテストケースを追加（合計 39 件 → 全て pass）
- README の API リファレンスと環境変数表を更新

## 動作確認

- `pytest -v` 全 39 件 pass
- `flake8 --max-line-length=120` でエラー無し
- 既存の type/status/limit/offset フィルタとの組み合わせも問題なし

Closes #26