### PR TITLE
feat: dashboard /api/timeline にフィルタ・bucket・limit指定を追加

### DIFF
--- a/dashboard/src/index.test.ts
+++ b/dashboard/src/index.test.ts
@@ -131,6 +131,72 @@ describe("Dashboard Service", () => {
       expect(res.body[0].count).toBe(2);
     });
 
+    it("should pass a high limit to gateway when fetching events", async () => {
+      mockedAxios.get.mockResolvedValueOnce({
+        data: { events: [], total: 0, limit: 1000, offset: 0 },
+        status: 200,
+        statusText: "OK",
+        headers: {},
+        config: {} as never,
+      });
+      await request(app).get("/api/timeline");
+      const calledUrl = mockedAxios.get.mock.calls[mockedAxios.get.mock.calls.length - 1][0];
+      expect(calledUrl).toContain("limit=1000");
+    });
+
+    it("should forward type/status/since/until filters to gateway", async () => {
+      mockedAxios.get.mockResolvedValueOnce({
+        data: { events: [], total: 0, limit: 1000, offset: 0 },
+        status: 200,
+        statusText: "OK",
+        headers: {},
+        config: {} as never,
+      });
+      await request(app).get(
+        "/api/timeline?type=user.signup&status=processed&since=1700000000&until=1800000000"
+      );
+      const calledUrl = mockedAxios.get.mock.calls[mockedAxios.get.mock.calls.length - 1][0];
+      expect(calledUrl).toContain("type=user.signup");
+      expect(calledUrl).toContain("status=processed");
+      expect(calledUrl).toContain("since=1700000000");
+      expect(calledUrl).toContain("until=1800000000");
+    });
+
+    it("should aggregate by day when bucket=day", async () => {
+      const t1 = new Date(2026, 0, 1, 3, 30).getTime() / 1000;
+      const t2 = new Date(2026, 0, 1, 18, 45).getTime() / 1000;
+      const t3 = new Date(2026, 0, 2, 10, 0).getTime() / 1000;
+      mockedAxios.get.mockResolvedValueOnce({
+        data: {
+          events: [
+            { timestamp: t1, type: "x", status: "received" },
+            { timestamp: t2, type: "x", status: "received" },
+            { timestamp: t3, type: "x", status: "received" },
+          ],
+          total: 3,
+          limit: 1000,
+          offset: 0,
+        },
+        status: 200,
+        statusText: "OK",
+        headers: {},
+        config: {} as never,
+      });
+      const res = await request(app).get("/api/timeline?bucket=day");
+      expect(res.status).toBe(200);
+      expect(res.body).toHaveLength(2);
+      expect(res.body[0]).toHaveProperty("day");
+      expect(res.body[0].count).toBe(2);
+      expect(res.body[1].count).toBe(1);
+    });
+
+    it("should reject invalid bucket values", async () => {
+      const res = await request(app).get("/api/timeline?bucket=week");
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe("Invalid bucket");
+      expect(res.body.allowed).toEqual(["day", "hour"]);
+    });
+
     it("should return 502 when gateway is unreachable", async () => {
       mockedAxios.get.mockRejectedValueOnce(new Error("ECONNREFUSED"));
       const res = await request(app).get("/api/timeline");

--- a/dashboard/src/index.ts
+++ b/dashboard/src/index.ts
@@ -9,6 +9,11 @@ app.use(express.json());
 const GATEWAY_URL = process.env.GATEWAY_URL || "http://localhost:8080";
 const PORT = parseInt(process.env.DASHBOARD_PORT || "3000", 10);
 const LOG_LEVEL = process.env.LOG_LEVEL || "info";
+const TIMELINE_FETCH_LIMIT = parseInt(
+  process.env.TIMELINE_FETCH_LIMIT || "1000",
+  10
+);
+const ALLOWED_BUCKETS = new Set(["hour", "day"]);
 
 function log(level: string, message: string): void {
   if (level === "debug" && LOG_LEVEL !== "debug") return;
@@ -69,24 +74,53 @@ app.get("/api/events", async (req: Request, res: Response) => {
   }
 });
 
-app.get("/api/timeline", async (_req: Request, res: Response) => {
-  try {
-    const resp = await axios.get(`${GATEWAY_URL}/api/events`, {
-      timeout: 5000,
+function bucketKey(date: Date, bucket: string): string {
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, "0");
+  const d = String(date.getDate()).padStart(2, "0");
+  if (bucket === "day") {
+    return `${y}-${m}-${d}`;
+  }
+  const h = String(date.getHours()).padStart(2, "0");
+  return `${y}-${m}-${d} ${h}:00`;
+}
+
+app.get("/api/timeline", async (req: Request, res: Response) => {
+  const bucket = req.query.bucket ? String(req.query.bucket) : "hour";
+  if (!ALLOWED_BUCKETS.has(bucket)) {
+    res.status(400).json({
+      error: "Invalid bucket",
+      allowed: Array.from(ALLOWED_BUCKETS).sort(),
     });
+    return;
+  }
+
+  try {
+    const params = new URLSearchParams();
+    if (req.query.type) params.set("type", String(req.query.type));
+    if (req.query.status) params.set("status", String(req.query.status));
+    if (req.query.since) params.set("since", String(req.query.since));
+    if (req.query.until) params.set("until", String(req.query.until));
+    params.set("limit", String(TIMELINE_FETCH_LIMIT));
+    const url = `${GATEWAY_URL}/api/events?${params.toString()}`;
+    const resp = await axios.get(url, { timeout: 5000 });
     const events: Array<{ timestamp: number; type: string; status: string }> =
-      resp.data.events;
+      resp.data.events || [];
 
     const buckets: Record<string, number> = {};
     for (const event of events) {
       const date = new Date(event.timestamp * 1000);
-      const key = `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}-${String(date.getDate()).padStart(2, "0")} ${String(date.getHours()).padStart(2, "0")}:00`;
+      const key = bucketKey(date, bucket);
       buckets[key] = (buckets[key] || 0) + 1;
     }
 
     const timeline = Object.entries(buckets)
-      .map(([hour, count]) => ({ hour, count }))
-      .sort((a, b) => a.hour.localeCompare(b.hour));
+      .map(([slot, count]) => ({ [bucket]: slot, count }))
+      .sort((a, b) =>
+        String(a[bucket as keyof typeof a]).localeCompare(
+          String(b[bucket as keyof typeof b])
+        )
+      );
 
     res.json(timeline);
   } catch (err) {


### PR DESCRIPTION
## 概要
- `/api/timeline` でタイムラインが gateway 既定の 50 件に制限されてしまう問題を修正
- `type` / `status` / `since` / `until` をクエリパラメータとして受け付け、gateway へ転送
- `TIMELINE_FETCH_LIMIT`（既定 1000）で取得上限を環境変数化
- `bucket=hour|day` で集計粒度を切替（不正値は 400 を返す）

## 動作確認
- `cd dashboard && npm install && npm run lint`
- `cd dashboard && npm test` → 14 passed

Closes #28