### PR TITLE
feat: gateway/dashboard の /api/stats に時系列・type・status フィルタを追加

### DIFF
--- a/dashboard/src/index.test.ts
+++ b/dashboard/src/index.test.ts
@@ -40,6 +40,56 @@ describe("Dashboard Service", () => {
     });
   });
 
+  describe("GET /api/stats", () => {
+    it("should proxy stats from gateway", async () => {
+      mockedAxios.get.mockResolvedValueOnce({
+        data: { total: 3, by_status: { received: 3 }, by_type: { x: 3 } },
+        status: 200,
+        statusText: "OK",
+        headers: {},
+        config: {} as never,
+      });
+      const res = await request(app).get("/api/stats");
+      expect(res.status).toBe(200);
+      expect(res.body.total).toBe(3);
+      expect(res.body.by_type).toEqual({ x: 3 });
+    });
+
+    it("should forward type/status/since/until filters to gateway", async () => {
+      mockedAxios.get.mockResolvedValueOnce({
+        data: { total: 0, by_status: {}, by_type: {} },
+        status: 200,
+        statusText: "OK",
+        headers: {},
+        config: {} as never,
+      });
+      await request(app).get(
+        "/api/stats?type=user.signup&status=processed&since=100&until=200"
+      );
+      const calledUrl = mockedAxios.get.mock.calls[mockedAxios.get.mock.calls.length - 1][0];
+      expect(calledUrl).toContain("type=user.signup");
+      expect(calledUrl).toContain("status=processed");
+      expect(calledUrl).toContain("since=100");
+      expect(calledUrl).toContain("until=200");
+    });
+
+    it("should propagate 4xx errors from gateway", async () => {
+      mockedAxios.get.mockRejectedValueOnce({
+        response: { status: 400, data: { error: "Invalid status" } },
+      });
+      const res = await request(app).get("/api/stats?status=bogus");
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe("Invalid status");
+    });
+
+    it("should return 502 when gateway is unreachable", async () => {
+      mockedAxios.get.mockRejectedValueOnce(new Error("ECONNREFUSED"));
+      const res = await request(app).get("/api/stats");
+      expect(res.status).toBe(502);
+      expect(res.body.error).toBeDefined();
+    });
+  });
+
   describe("GET /api/events", () => {
     it("should proxy events from gateway", async () => {
       mockedAxios.get.mockResolvedValueOnce({

--- a/dashboard/src/index.ts
+++ b/dashboard/src/index.ts
@@ -56,6 +56,30 @@ app.get("/api/dashboard", async (_req: Request, res: Response) => {
   res.json(snapshot);
 });
 
+app.get("/api/stats", async (req: Request, res: Response) => {
+  try {
+    const params = new URLSearchParams();
+    if (req.query.type) params.set("type", String(req.query.type));
+    if (req.query.status) params.set("status", String(req.query.status));
+    if (req.query.since) params.set("since", String(req.query.since));
+    if (req.query.until) params.set("until", String(req.query.until));
+    const qs = params.toString();
+    const url = qs ? `${GATEWAY_URL}/api/stats?${qs}` : `${GATEWAY_URL}/api/stats`;
+    const resp = await axios.get(url, { timeout: 5000 });
+    log("info", `Fetched stats from gateway (total: ${resp.data.total})`);
+    res.json(resp.data);
+  } catch (err) {
+    const e = err as { response?: { status: number; data: unknown } };
+    if (e.response && e.response.status >= 400 && e.response.status < 500) {
+      log("warn", `Gateway rejected stats request: ${e.response.status}`);
+      res.status(e.response.status).json(e.response.data);
+      return;
+    }
+    log("error", `Failed to fetch stats: ${err}`);
+    res.status(502).json({ error: "Failed to fetch stats from gateway" });
+  }
+});
+
 app.get("/api/events", async (req: Request, res: Response) => {
   try {
     const params = new URLSearchParams();

--- a/gateway/app.py
+++ b/gateway/app.py
@@ -198,13 +198,49 @@ def delete_event(event_id):
 
 @app.route("/api/stats", methods=["GET"])
 def stats():
-    total = len(events_store)
-    by_status = {}
-    by_type = {}
-    for e in events_store:
+    event_type = request.args.get("type")
+    status = request.args.get("status")
+    since_raw = request.args.get("since")
+    until_raw = request.args.get("until")
+
+    if status is not None and status not in ALLOWED_STATUSES:
+        logger.warning("Invalid status filter on stats: %s", status)
+        return jsonify({
+            "error": "Invalid status",
+            "allowed": sorted(ALLOWED_STATUSES),
+        }), 400
+
+    since = None
+    until = None
+    try:
+        if since_raw is not None:
+            since = _parse_timestamp_arg(since_raw, "since")
+        if until_raw is not None:
+            until = _parse_timestamp_arg(until_raw, "until")
+    except ValueError as e:
+        logger.warning("Invalid timestamp filter on stats: %s", e)
+        return jsonify({"error": str(e)}), 400
+
+    if since is not None and until is not None and until < since:
+        logger.warning("Invalid range on stats: until=%s < since=%s", until, since)
+        return jsonify({"error": "'until' must be greater than or equal to 'since'"}), 400
+
+    filtered = events_store
+    if event_type:
+        filtered = [e for e in filtered if e["type"] == event_type]
+    if status:
+        filtered = [e for e in filtered if e.get("status") == status]
+    if since is not None:
+        filtered = [e for e in filtered if e.get("timestamp", 0) >= since]
+    if until is not None:
+        filtered = [e for e in filtered if e.get("timestamp", 0) <= until]
+
+    by_status: dict[str, int] = {}
+    by_type: dict[str, int] = {}
+    for e in filtered:
         by_status[e["status"]] = by_status.get(e["status"], 0) + 1
         by_type[e["type"]] = by_type.get(e["type"], 0) + 1
-    return jsonify({"total": total, "by_status": by_status, "by_type": by_type})
+    return jsonify({"total": len(filtered), "by_status": by_status, "by_type": by_type})
 
 
 def create_app():

--- a/gateway/test_app.py
+++ b/gateway/test_app.py
@@ -330,6 +330,73 @@ def test_stats_with_events(client):
     assert data["by_type"]["stat.test"] == 2
 
 
+def test_stats_filter_by_type(client):
+    client.post(
+        "/api/events",
+        data=json.dumps({"type": "stat.a"}),
+        content_type="application/json",
+    )
+    client.post(
+        "/api/events",
+        data=json.dumps({"type": "stat.b"}),
+        content_type="application/json",
+    )
+    resp = client.get("/api/stats?type=stat.a")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["total"] == 1
+    assert data["by_type"] == {"stat.a": 1}
+
+
+def test_stats_filter_by_status(client):
+    events_store.append({
+        "id": "1", "type": "x", "payload": {}, "timestamp": 100.0, "status": "received",
+    })
+    events_store.append({
+        "id": "2", "type": "x", "payload": {}, "timestamp": 200.0, "status": "processed",
+    })
+    resp = client.get("/api/stats?status=processed")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["total"] == 1
+    assert data["by_status"] == {"processed": 1}
+
+
+def test_stats_filter_by_time_range(client):
+    events_store.append({
+        "id": "1", "type": "x", "payload": {}, "timestamp": 100.0, "status": "received",
+    })
+    events_store.append({
+        "id": "2", "type": "x", "payload": {}, "timestamp": 200.0, "status": "received",
+    })
+    events_store.append({
+        "id": "3", "type": "x", "payload": {}, "timestamp": 300.0, "status": "received",
+    })
+    resp = client.get("/api/stats?since=150&until=250")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["total"] == 1
+
+
+def test_stats_invalid_status(client):
+    resp = client.get("/api/stats?status=bogus")
+    assert resp.status_code == 400
+    data = resp.get_json()
+    assert "allowed" in data
+
+
+def test_stats_invalid_since(client):
+    resp = client.get("/api/stats?since=notanumber")
+    assert resp.status_code == 400
+    data = resp.get_json()
+    assert "since" in data["error"]
+
+
+def test_stats_until_before_since(client):
+    resp = client.get("/api/stats?since=200&until=100")
+    assert resp.status_code == 400
+
+
 def test_events_store_max_capacity(client, monkeypatch):
     monkeypatch.setattr("app.MAX_EVENTS", 3)
     for i in range(5):


### PR DESCRIPTION
## 概要

- gateway `/api/stats` に `type / status / since / until` のクエリパラメータを追加し、`/api/events` と同じバリデーションロジックを共用
- 不正な status / 数値 / since>until は 400 を返す
- dashboard 側に `/api/stats` プロキシを新設し、上記パラメータをそのまま転送（gateway の 4xx は伝播、ネットワーク障害は 502）
- gateway / dashboard 両方にユニットテストを追加（type / status / since-until / 不正値）

## 対応 Issue

Closes #30

## 動作確認

- [x] `cd gateway && pytest -v` → 45 件すべてパス
- [x] `cd gateway && flake8 --max-line-length=120 .` → 警告なし
- [x] `cd dashboard && npm test` → 18 件すべてパス
- [x] `cd dashboard && npx eslint src/` → 警告なし