### PR TITLE
fix(gateway): events_store のスレッドセーフ化と list_events のソート機能追加

### DIFF
--- a/gateway/app.py
+++ b/gateway/app.py
@@ -1,5 +1,6 @@
 import os
 import logging
+import threading
 import time
 import uuid
 
@@ -25,8 +26,11 @@ DEFAULT_PAGE_LIMIT = int(os.environ.get("DEFAULT_PAGE_LIMIT", "50"))
 MAX_PAGE_LIMIT = int(os.environ.get("MAX_PAGE_LIMIT", "500"))
 
 ALLOWED_STATUSES = {"received", "processed", "process_failed", "process_error"}
+ALLOWED_SORT_FIELDS = {"timestamp", "type", "status"}
+ALLOWED_SORT_ORDERS = {"asc", "desc"}
 
 events_store: list[dict] = []
+events_lock = threading.Lock()
 
 
 @app.before_request
@@ -95,12 +99,12 @@ def create_event():
         "timestamp": time.time(),
         "status": "received",
     }
-    events_store.append(event)
-
-    if len(events_store) > MAX_EVENTS:
-        removed = len(events_store) - MAX_EVENTS
-        del events_store[:removed]
-        logger.info("Evicted %d old events (store capped at %d)", removed, MAX_EVENTS)
+    with events_lock:
+        events_store.append(event)
+        if len(events_store) > MAX_EVENTS:
+            removed = len(events_store) - MAX_EVENTS
+            del events_store[:removed]
+            logger.info("Evicted %d old events (store capped at %d)", removed, MAX_EVENTS)
 
     logger.info("Event created: id=%s type=%s", event["id"], event["type"])
 
@@ -143,12 +147,28 @@ def list_events():
     offset = request.args.get("offset", 0, type=int)
     since_raw = request.args.get("since")
     until_raw = request.args.get("until")
+    sort_field = request.args.get("sort", "timestamp")
+    sort_order = request.args.get("order", "asc")
 
     if status is not None and status not in ALLOWED_STATUSES:
         logger.warning("Invalid status filter: %s", status)
         return jsonify({
             "error": "Invalid status",
             "allowed": sorted(ALLOWED_STATUSES),
+        }), 400
+
+    if sort_field not in ALLOWED_SORT_FIELDS:
+        logger.warning("Invalid sort field: %s", sort_field)
+        return jsonify({
+            "error": "Invalid sort field",
+            "allowed": sorted(ALLOWED_SORT_FIELDS),
+        }), 400
+
+    if sort_order not in ALLOWED_SORT_ORDERS:
+        logger.warning("Invalid sort order: %s", sort_order)
+        return jsonify({
+            "error": "Invalid sort order",
+            "allowed": sorted(ALLOWED_SORT_ORDERS),
         }), 400
 
     since = None
@@ -173,7 +193,9 @@ def list_events():
     if offset < 0:
         offset = 0
 
-    filtered = events_store
+    with events_lock:
+        filtered = list(events_store)
+
     if event_type:
         filtered = [e for e in filtered if e["type"] == event_type]
     if status:
@@ -183,6 +205,9 @@ def list_events():
     if until is not None:
         filtered = [e for e in filtered if e.get("timestamp", 0) <= until]
 
+    reverse = sort_order == "desc"
+    filtered.sort(key=lambda e: e.get(sort_field, ""), reverse=reverse)
+
     total = len(filtered)
     paginated = filtered[offset:offset + limit]
 
@@ -191,25 +216,29 @@ def list_events():
         "total": total,
         "limit": limit,
         "offset": offset,
+        "sort": sort_field,
+        "order": sort_order,
     })
 
 
 @app.route("/api/events/<event_id>", methods=["GET"])
 def get_event(event_id):
-    for event in events_store:
-        if event["id"] == event_id:
-            return jsonify(event)
+    with events_lock:
+        for event in events_store:
+            if event["id"] == event_id:
+                return jsonify(event)
     logger.warning("Event not found: %s", event_id)
     return jsonify({"error": "Event not found"}), 404
 
 
 @app.route("/api/events/<event_id>", methods=["DELETE"])
 def delete_event(event_id):
-    for i, event in enumerate(events_store):
-        if event["id"] == event_id:
-            deleted = events_store.pop(i)
-            logger.info("Event deleted: id=%s type=%s", deleted["id"], deleted["type"])
-            return jsonify({"message": "Event deleted", "event": deleted})
+    with events_lock:
+        for i, event in enumerate(events_store):
+            if event["id"] == event_id:
+                deleted = events_store.pop(i)
+                logger.info("Event deleted: id=%s type=%s", deleted["id"], deleted["type"])
+                return jsonify({"message": "Event deleted", "event": deleted})
     logger.warning("Event not found for deletion: %s", event_id)
     return jsonify({"error": "Event not found"}), 404
 
@@ -243,7 +272,8 @@ def stats():
         logger.warning("Invalid range on stats: until=%s < since=%s", until, since)
         return jsonify({"error": "'until' must be greater than or equal to 'since'"}), 400
 
-    filtered = events_store
+    with events_lock:
+        filtered = list(events_store)
     if event_type:
         filtered = [e for e in filtered if e["type"] == event_type]
     if status:

--- a/gateway/test_app.py
+++ b/gateway/test_app.py
@@ -615,3 +615,96 @@ def test_create_event_trims_surrounding_whitespace(client):
     assert resp.status_code == 201
     data = resp.get_json()
     assert data["type"] == "user.signup"
+
+
+def test_list_events_sort_default_is_timestamp_asc(client):
+    events_store.append({
+        "id": "a", "type": "x", "payload": {}, "timestamp": 300.0, "status": "received",
+    })
+    events_store.append({
+        "id": "b", "type": "x", "payload": {}, "timestamp": 100.0, "status": "received",
+    })
+    events_store.append({
+        "id": "c", "type": "x", "payload": {}, "timestamp": 200.0, "status": "received",
+    })
+    resp = client.get("/api/events")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert [e["id"] for e in data["events"]] == ["b", "c", "a"]
+    assert data["sort"] == "timestamp"
+    assert data["order"] == "asc"
+
+
+def test_list_events_sort_timestamp_desc(client):
+    events_store.append({
+        "id": "a", "type": "x", "payload": {}, "timestamp": 100.0, "status": "received",
+    })
+    events_store.append({
+        "id": "b", "type": "x", "payload": {}, "timestamp": 300.0, "status": "received",
+    })
+    events_store.append({
+        "id": "c", "type": "x", "payload": {}, "timestamp": 200.0, "status": "received",
+    })
+    resp = client.get("/api/events?order=desc")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert [e["id"] for e in data["events"]] == ["b", "c", "a"]
+
+
+def test_list_events_sort_by_type(client):
+    events_store.append({
+        "id": "1", "type": "zebra", "payload": {}, "timestamp": 1.0, "status": "received",
+    })
+    events_store.append({
+        "id": "2", "type": "apple", "payload": {}, "timestamp": 2.0, "status": "received",
+    })
+    resp = client.get("/api/events?sort=type")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert [e["type"] for e in data["events"]] == ["apple", "zebra"]
+
+
+def test_list_events_invalid_sort_field(client):
+    resp = client.get("/api/events?sort=bogus")
+    assert resp.status_code == 400
+    data = resp.get_json()
+    assert "allowed" in data
+
+
+def test_list_events_invalid_sort_order(client):
+    resp = client.get("/api/events?order=sideways")
+    assert resp.status_code == 400
+    data = resp.get_json()
+    assert "allowed" in data
+
+
+def test_events_store_lock_is_threadlock():
+    from app import events_lock
+    import threading as _threading
+    assert isinstance(events_lock, type(_threading.Lock()))
+
+
+def test_events_store_concurrent_appends_no_loss():
+    from app import events_store as store, events_lock
+    import threading as _threading
+
+    store.clear()
+
+    def writer(prefix):
+        for i in range(50):
+            with events_lock:
+                store.append({
+                    "id": f"{prefix}-{i}",
+                    "type": prefix,
+                    "payload": {},
+                    "timestamp": float(i),
+                    "status": "received",
+                })
+
+    threads = [_threading.Thread(target=writer, args=(f"t{i}",)) for i in range(5)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert len(store) == 5 * 50


### PR DESCRIPTION
## 変更概要

- `gateway/app.py` に `threading.Lock` (`events_lock`) を導入し、`events_store` への append / pop / iterate を排他制御
- `list_events` に `sort`(`timestamp` / `type` / `status`)と `order`(`asc` / `desc`)クエリパラメータを追加。不正値は 400 を返す。レスポンスにも `sort` / `order` を含める
- `gateway/test_app.py` に並び替えとロック動作のテスト 7 件を追加

Closes #33

## 動作確認

- `cd gateway && python -m pytest test_app.py -q` → 57 件すべてパス
- `python -m flake8 app.py test_app.py --max-line-length=120` → 警告なし
- 既存の 50 テストは変更なくパス、追加した 7 テストでソート挙動・バリデーション・並行 append でのロス無しを検証