### PR TITLE
perf(gateway): イベント ID 参照を O(1) インデックスに置き換え

### DIFF
--- a/gateway/app.py
+++ b/gateway/app.py
@@ -30,6 +30,7 @@ ALLOWED_SORT_FIELDS = {"timestamp", "type", "status"}
 ALLOWED_SORT_ORDERS = {"asc", "desc"}
 
 events_store: list[dict] = []
+events_index: dict[str, dict] = {}
 events_lock = threading.Lock()
 
 
@@ -101,9 +102,13 @@ def create_event():
     }
     with events_lock:
         events_store.append(event)
+        events_index[event["id"]] = event
         if len(events_store) > MAX_EVENTS:
             removed = len(events_store) - MAX_EVENTS
+            evicted = events_store[:removed]
             del events_store[:removed]
+            for e in evicted:
+                events_index.pop(e["id"], None)
             logger.info("Evicted %d old events (store capped at %d)", removed, MAX_EVENTS)
 
     logger.info("Event created: id=%s type=%s", event["id"], event["type"])
@@ -224,9 +229,9 @@ def list_events():
 @app.route("/api/events/<event_id>", methods=["GET"])
 def get_event(event_id):
     with events_lock:
-        for event in events_store:
-            if event["id"] == event_id:
-                return jsonify(event)
+        event = events_index.get(event_id)
+        if event is not None:
+            return jsonify(event)
     logger.warning("Event not found: %s", event_id)
     return jsonify({"error": "Event not found"}), 404
 
@@ -234,11 +239,14 @@ def get_event(event_id):
 @app.route("/api/events/<event_id>", methods=["DELETE"])
 def delete_event(event_id):
     with events_lock:
-        for i, event in enumerate(events_store):
-            if event["id"] == event_id:
-                deleted = events_store.pop(i)
-                logger.info("Event deleted: id=%s type=%s", deleted["id"], deleted["type"])
-                return jsonify({"message": "Event deleted", "event": deleted})
+        event = events_index.pop(event_id, None)
+        if event is not None:
+            try:
+                events_store.remove(event)
+            except ValueError:
+                pass
+            logger.info("Event deleted: id=%s type=%s", event["id"], event["type"])
+            return jsonify({"message": "Event deleted", "event": event})
     logger.warning("Event not found for deletion: %s", event_id)
     return jsonify({"error": "Event not found"}), 404
 

--- a/gateway/test_app.py
+++ b/gateway/test_app.py
@@ -1,14 +1,16 @@
 import json
 import uuid
 import pytest
-from app import app, events_store
+from app import app, events_store, events_index
 
 
 @pytest.fixture(autouse=True)
 def clear_events():
     events_store.clear()
+    events_index.clear()
     yield
     events_store.clear()
+    events_index.clear()
 
 
 @pytest.fixture
@@ -708,3 +710,55 @@ def test_events_store_concurrent_appends_no_loss():
         t.join()
 
     assert len(store) == 5 * 50
+
+
+def test_events_index_indexes_created_events(client):
+    create_resp = client.post(
+        "/api/events",
+        data=json.dumps({"type": "idx.create"}),
+        content_type="application/json",
+    )
+    event_id = create_resp.get_json()["id"]
+    assert event_id in events_index
+    assert events_index[event_id]["type"] == "idx.create"
+
+
+def test_events_index_removed_on_delete(client):
+    create_resp = client.post(
+        "/api/events",
+        data=json.dumps({"type": "idx.del"}),
+        content_type="application/json",
+    )
+    event_id = create_resp.get_json()["id"]
+    assert event_id in events_index
+
+    client.delete(f"/api/events/{event_id}")
+    assert event_id not in events_index
+
+
+def test_events_index_evicted_when_store_capacity_exceeded(client, monkeypatch):
+    monkeypatch.setattr("app.MAX_EVENTS", 3)
+    ids = []
+    for i in range(5):
+        resp = client.post(
+            "/api/events",
+            data=json.dumps({"type": f"cap.idx.{i}"}),
+            content_type="application/json",
+        )
+        ids.append(resp.get_json()["id"])
+    # Oldest two should be evicted from both store and index
+    assert ids[0] not in events_index
+    assert ids[1] not in events_index
+    assert ids[4] in events_index
+    assert len(events_index) == 3
+    assert len(events_store) == 3
+
+
+def test_events_index_size_matches_store(client):
+    for i in range(10):
+        client.post(
+            "/api/events",
+            data=json.dumps({"type": f"sync.{i}"}),
+            content_type="application/json",
+        )
+    assert len(events_index) == len(events_store)


### PR DESCRIPTION
## 変更概要

- `gateway/app.py` に `events_index: dict[str, dict]` を追加し、ID→Event の O(1) ルックアップを実現
- `create_event` でストア追加と同時にインデックス登録、容量超過エヴィクション時は両方から同期削除
- `get_event` / `delete_event` をリスト線形スキャンから dict 参照に変更（MAX_EVENTS=10000 規模でも一定時間アクセス）
- `gateway/test_app.py` の fixture でインデックスもクリアし、整合性テストを 4 件追加（作成・削除・エヴィクション・サイズ同期）

Closes #35

## 動作確認手順

```
cd gateway
pip install -r requirements-dev.txt
pytest -v        # 61 passed (新規 4 件を含む)
flake8 --max-line-length=120 --exclude=__pycache__ .
```