### PR TITLE
feat: dashboard /api/events に since/until/sort/order を転送し 4xx を伝播する

### DIFF
--- a/dashboard/src/index.test.ts
+++ b/dashboard/src/index.test.ts
@@ -147,6 +147,43 @@ describe("Dashboard Service", () => {
       expect(calledUrl).toContain("status=process_failed");
     });
 
+    it("should forward since/until filters to gateway", async () => {
+      mockedAxios.get.mockResolvedValueOnce({
+        data: { events: [], total: 0, limit: 50, offset: 0 },
+        status: 200,
+        statusText: "OK",
+        headers: {},
+        config: {} as never,
+      });
+      await request(app).get("/api/events?since=1700000000&until=1800000000");
+      const calledUrl = mockedAxios.get.mock.calls[mockedAxios.get.mock.calls.length - 1][0];
+      expect(calledUrl).toContain("since=1700000000");
+      expect(calledUrl).toContain("until=1800000000");
+    });
+
+    it("should forward sort and order parameters to gateway", async () => {
+      mockedAxios.get.mockResolvedValueOnce({
+        data: { events: [], total: 0, limit: 50, offset: 0, sort: "timestamp", order: "desc" },
+        status: 200,
+        statusText: "OK",
+        headers: {},
+        config: {} as never,
+      });
+      await request(app).get("/api/events?sort=type&order=desc");
+      const calledUrl = mockedAxios.get.mock.calls[mockedAxios.get.mock.calls.length - 1][0];
+      expect(calledUrl).toContain("sort=type");
+      expect(calledUrl).toContain("order=desc");
+    });
+
+    it("should propagate 4xx errors from gateway", async () => {
+      mockedAxios.get.mockRejectedValueOnce({
+        response: { status: 400, data: { error: "Invalid sort field" } },
+      });
+      const res = await request(app).get("/api/events?sort=bogus");
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe("Invalid sort field");
+    });
+
     it("should return 502 when gateway is unreachable", async () => {
       mockedAxios.get.mockRejectedValueOnce(new Error("ECONNREFUSED"));
       const res = await request(app).get("/api/events");

--- a/dashboard/src/index.ts
+++ b/dashboard/src/index.ts
@@ -87,12 +87,22 @@ app.get("/api/events", async (req: Request, res: Response) => {
     if (req.query.status) params.set("status", String(req.query.status));
     if (req.query.limit) params.set("limit", String(req.query.limit));
     if (req.query.offset) params.set("offset", String(req.query.offset));
+    if (req.query.since) params.set("since", String(req.query.since));
+    if (req.query.until) params.set("until", String(req.query.until));
+    if (req.query.sort) params.set("sort", String(req.query.sort));
+    if (req.query.order) params.set("order", String(req.query.order));
     const qs = params.toString();
     const url = qs ? `${GATEWAY_URL}/api/events?${qs}` : `${GATEWAY_URL}/api/events`;
     const resp = await axios.get(url, { timeout: 5000 });
     log("info", `Fetched events from gateway (total: ${resp.data.total})`);
     res.json(resp.data);
   } catch (err) {
+    const e = err as { response?: { status: number; data: unknown } };
+    if (e.response && e.response.status >= 400 && e.response.status < 500) {
+      log("warn", `Gateway rejected events request: ${e.response.status}`);
+      res.status(e.response.status).json(e.response.data);
+      return;
+    }
     log("error", `Failed to fetch events: ${err}`);
     res.status(502).json({ error: "Failed to fetch events from gateway" });
   }


### PR DESCRIPTION
## 概要

- `dashboard/src/index.ts` の `/api/events` プロキシに `since`/`until`/`sort`/`order` の query string 転送を追加
- 4xx エラーは Gateway からのレスポンスを透過伝播（既存の `/api/stats` と同じパターン）
- 5xx・ネットワーク不通は 502 を返す

## 動作確認

- `npm test` (jest): 21件全部 pass
- `npm run lint` (eslint): エラーなし
- `tsc --noEmit`: エラーなし

Closes #37