### PR TITLE
feat(processor): GET /processed に since/until/sort/order フィルタを追加

### DIFF
--- a/processor/main.go
+++ b/processor/main.go
@@ -6,9 +6,11 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"math"
 	"net/http"
 	"os"
 	"os/signal"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -55,6 +57,16 @@ var (
 const defaultMaxBodySize int64 = 1 << 20 // 1 MiB
 
 var allowedPriorities = map[string]bool{"high": true, "medium": true, "low": true}
+
+var allowedProcessedSortFields = map[string]bool{
+	"processed_at": true,
+	"priority":     true,
+	"event_id":     true,
+}
+
+var allowedProcessedSortOrders = map[string]bool{"asc": true, "desc": true}
+
+var priorityRank = map[string]int{"low": 0, "medium": 1, "high": 2}
 
 func envSeconds(key string, fallback time.Duration) time.Duration {
 	if v := os.Getenv(key); v != "" {
@@ -225,11 +237,27 @@ func parsePositiveIntQuery(r *http.Request, key string, fallback int) int {
 	return n
 }
 
+func parseTimestampQuery(value string) (float64, error) {
+	v, err := strconv.ParseFloat(value, 64)
+	if err != nil {
+		return 0, fmt.Errorf("must be a numeric Unix timestamp")
+	}
+	if math.IsNaN(v) || math.IsInf(v, 0) {
+		return 0, fmt.Errorf("must be a finite number")
+	}
+	if v < 0 {
+		return 0, fmt.Errorf("must be non-negative")
+	}
+	return v, nil
+}
+
 type processedResponse struct {
 	Results []ProcessResult `json:"results"`
 	Total   int             `json:"total"`
 	Limit   int             `json:"limit"`
 	Offset  int             `json:"offset"`
+	Sort    string          `json:"sort"`
+	Order   string          `json:"order"`
 }
 
 func processedHandler(w http.ResponseWriter, r *http.Request) {
@@ -237,26 +265,110 @@ func processedHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	query := r.URL.Query()
 	limit := parsePositiveIntQuery(r, "limit", processedDefaultLimit)
 	offset := parsePositiveIntQuery(r, "offset", 0)
-	priority := strings.ToLower(strings.TrimSpace(r.URL.Query().Get("priority")))
+	priority := strings.ToLower(strings.TrimSpace(query.Get("priority")))
 	if priority != "" && !allowedPriorities[priority] {
 		http.Error(w, `{"error":"priority must be one of: high, medium, low"}`, http.StatusBadRequest)
+		return
+	}
+
+	sortField := query.Get("sort")
+	if sortField == "" {
+		sortField = "processed_at"
+	}
+	if !allowedProcessedSortFields[sortField] {
+		http.Error(
+			w,
+			`{"error":"sort must be one of: event_id, priority, processed_at"}`,
+			http.StatusBadRequest,
+		)
+		return
+	}
+
+	sortOrder := query.Get("order")
+	if sortOrder == "" {
+		sortOrder = "asc"
+	}
+	if !allowedProcessedSortOrders[sortOrder] {
+		http.Error(w, `{"error":"order must be one of: asc, desc"}`, http.StatusBadRequest)
+		return
+	}
+
+	var since, until *float64
+	if raw := query.Get("since"); raw != "" {
+		v, err := parseTimestampQuery(raw)
+		if err != nil {
+			http.Error(
+				w,
+				fmt.Sprintf(`{"error":"query parameter 'since' %s"}`, err.Error()),
+				http.StatusBadRequest,
+			)
+			return
+		}
+		since = &v
+	}
+	if raw := query.Get("until"); raw != "" {
+		v, err := parseTimestampQuery(raw)
+		if err != nil {
+			http.Error(
+				w,
+				fmt.Sprintf(`{"error":"query parameter 'until' %s"}`, err.Error()),
+				http.StatusBadRequest,
+			)
+			return
+		}
+		until = &v
+	}
+	if since != nil && until != nil && *until < *since {
+		http.Error(
+			w,
+			`{"error":"query parameter 'until' must be greater than or equal to 'since'"}`,
+			http.StatusBadRequest,
+		)
 		return
 	}
 
 	mu.Lock()
 	defer mu.Unlock()
 
-	filtered := processedEvents
-	if priority != "" {
-		filtered = make([]ProcessResult, 0, len(processedEvents))
-		for _, e := range processedEvents {
-			if e.Priority == priority {
-				filtered = append(filtered, e)
-			}
+	filtered := make([]ProcessResult, 0, len(processedEvents))
+	for _, e := range processedEvents {
+		if priority != "" && e.Priority != priority {
+			continue
 		}
+		if since != nil && e.ProcessedAt < *since {
+			continue
+		}
+		if until != nil && e.ProcessedAt > *until {
+			continue
+		}
+		filtered = append(filtered, e)
 	}
+
+	reverse := sortOrder == "desc"
+	sort.SliceStable(filtered, func(i, j int) bool {
+		a, b := filtered[i], filtered[j]
+		switch sortField {
+		case "processed_at":
+			if reverse {
+				return a.ProcessedAt > b.ProcessedAt
+			}
+			return a.ProcessedAt < b.ProcessedAt
+		case "priority":
+			if reverse {
+				return priorityRank[a.Priority] > priorityRank[b.Priority]
+			}
+			return priorityRank[a.Priority] < priorityRank[b.Priority]
+		case "event_id":
+			if reverse {
+				return a.EventID > b.EventID
+			}
+			return a.EventID < b.EventID
+		}
+		return false
+	})
 
 	total := len(filtered)
 	start := offset
@@ -279,6 +391,8 @@ func processedHandler(w http.ResponseWriter, r *http.Request) {
 		Total:   total,
 		Limit:   limit,
 		Offset:  offset,
+		Sort:    sortField,
+		Order:   sortOrder,
 	})
 }
 

--- a/processor/main_test.go
+++ b/processor/main_test.go
@@ -507,6 +507,159 @@ func TestProcessHandler_BodyWithinLimit(t *testing.T) {
 	}
 }
 
+func TestProcessedHandler_SinceUntilFilter(t *testing.T) {
+	resetProcessedEvents()
+
+	now := float64(time.Now().UnixMilli()) / 1000.0
+	mu.Lock()
+	processedEvents = []ProcessResult{
+		{EventID: "old", ProcessedAt: now - 100, Priority: "low", Tags: []string{"a"}},
+		{EventID: "mid", ProcessedAt: now - 50, Priority: "medium", Tags: []string{"b"}},
+		{EventID: "new", ProcessedAt: now, Priority: "high", Tags: []string{"c"}},
+	}
+	mu.Unlock()
+
+	url := fmt.Sprintf("/processed?since=%f&until=%f", now-60, now-10)
+	req := httptest.NewRequest(http.MethodGet, url, nil)
+	w := httptest.NewRecorder()
+	processedHandler(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d (body=%s)", w.Code, w.Body.String())
+	}
+
+	var resp processedResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode failed: %v", err)
+	}
+	if resp.Total != 1 {
+		t.Fatalf("expected total 1, got %d", resp.Total)
+	}
+	if resp.Results[0].EventID != "mid" {
+		t.Fatalf("expected mid, got %s", resp.Results[0].EventID)
+	}
+}
+
+func TestProcessedHandler_InvalidSinceUntil(t *testing.T) {
+	resetProcessedEvents()
+
+	cases := []struct {
+		name string
+		q    string
+	}{
+		{"non-numeric since", "/processed?since=abc"},
+		{"non-numeric until", "/processed?until=xyz"},
+		{"negative since", "/processed?since=-1"},
+		{"until less than since", "/processed?since=100&until=50"},
+	}
+	for _, tc := range cases {
+		req := httptest.NewRequest(http.MethodGet, tc.q, nil)
+		w := httptest.NewRecorder()
+		processedHandler(w, req)
+		if w.Code != http.StatusBadRequest {
+			t.Errorf("%s: expected 400, got %d (%s)", tc.name, w.Code, w.Body.String())
+		}
+	}
+}
+
+func TestProcessedHandler_SortByProcessedAtDesc(t *testing.T) {
+	resetProcessedEvents()
+
+	mu.Lock()
+	processedEvents = []ProcessResult{
+		{EventID: "a", ProcessedAt: 100.0, Priority: "low"},
+		{EventID: "b", ProcessedAt: 300.0, Priority: "low"},
+		{EventID: "c", ProcessedAt: 200.0, Priority: "low"},
+	}
+	mu.Unlock()
+
+	req := httptest.NewRequest(http.MethodGet, "/processed?sort=processed_at&order=desc", nil)
+	w := httptest.NewRecorder()
+	processedHandler(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	var resp processedResponse
+	json.NewDecoder(w.Body).Decode(&resp)
+	if resp.Sort != "processed_at" || resp.Order != "desc" {
+		t.Errorf("expected sort=processed_at order=desc, got sort=%s order=%s", resp.Sort, resp.Order)
+	}
+	if resp.Results[0].EventID != "b" || resp.Results[1].EventID != "c" || resp.Results[2].EventID != "a" {
+		t.Errorf("unexpected order: %s, %s, %s",
+			resp.Results[0].EventID, resp.Results[1].EventID, resp.Results[2].EventID)
+	}
+}
+
+func TestProcessedHandler_SortByPriorityAsc(t *testing.T) {
+	resetProcessedEvents()
+
+	mu.Lock()
+	processedEvents = []ProcessResult{
+		{EventID: "h", ProcessedAt: 1.0, Priority: "high"},
+		{EventID: "l", ProcessedAt: 2.0, Priority: "low"},
+		{EventID: "m", ProcessedAt: 3.0, Priority: "medium"},
+	}
+	mu.Unlock()
+
+	req := httptest.NewRequest(http.MethodGet, "/processed?sort=priority&order=asc", nil)
+	w := httptest.NewRecorder()
+	processedHandler(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	var resp processedResponse
+	json.NewDecoder(w.Body).Decode(&resp)
+	if resp.Results[0].Priority != "low" || resp.Results[1].Priority != "medium" || resp.Results[2].Priority != "high" {
+		t.Errorf("unexpected order: %s, %s, %s",
+			resp.Results[0].Priority, resp.Results[1].Priority, resp.Results[2].Priority)
+	}
+}
+
+func TestProcessedHandler_SortByEventIDDesc(t *testing.T) {
+	resetProcessedEvents()
+
+	mu.Lock()
+	processedEvents = []ProcessResult{
+		{EventID: "alpha", ProcessedAt: 1.0, Priority: "low"},
+		{EventID: "charlie", ProcessedAt: 2.0, Priority: "low"},
+		{EventID: "bravo", ProcessedAt: 3.0, Priority: "low"},
+	}
+	mu.Unlock()
+
+	req := httptest.NewRequest(http.MethodGet, "/processed?sort=event_id&order=desc", nil)
+	w := httptest.NewRecorder()
+	processedHandler(w, req)
+
+	var resp processedResponse
+	json.NewDecoder(w.Body).Decode(&resp)
+	if resp.Results[0].EventID != "charlie" || resp.Results[2].EventID != "alpha" {
+		t.Errorf("unexpected order: %s, %s, %s",
+			resp.Results[0].EventID, resp.Results[1].EventID, resp.Results[2].EventID)
+	}
+}
+
+func TestProcessedHandler_InvalidSort(t *testing.T) {
+	resetProcessedEvents()
+	req := httptest.NewRequest(http.MethodGet, "/processed?sort=bogus", nil)
+	w := httptest.NewRecorder()
+	processedHandler(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestProcessedHandler_InvalidOrder(t *testing.T) {
+	resetProcessedEvents()
+	req := httptest.NewRequest(http.MethodGet, "/processed?order=sideways", nil)
+	w := httptest.NewRecorder()
+	processedHandler(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
 func TestEnvSeconds_OverrideAndFallback(t *testing.T) {
 	const key = "TEST_PROCESSOR_ENV_SECONDS"
 	os.Unsetenv(key)


### PR DESCRIPTION
## 概要

- `processor` の `GET /processed` に時系列フィルタとソート機能を追加
- gateway / dashboard 側で先行実装されたフィルタ API と整合

## 追加クエリパラメータ

- `since` / `until`: Unix 秒で `processed_at` を範囲指定（非負・有限な数値のみ。`until < since` は 400）
- `sort`: `processed_at`（既定）/ `priority` / `event_id`
- `order`: `asc`（既定）/ `desc`
- 不正値はすべて 400 を返す

## 変更ファイル

- `processor/main.go`
- `processor/main_test.go`

## 動作確認

- `go vet ./...` がパス
- `go test -v ./...` で全テスト（新規 7 件を含む）がパス

Closes #39